### PR TITLE
Allow dependencies that use GStrings

### DIFF
--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependenciesHandler.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependenciesHandler.groovy
@@ -62,7 +62,7 @@ class DependenciesHandler {
     }
 
     def dependency(def id, Closure closure) {
-        if (id instanceof String) {
+        if (id instanceof String || id instanceof GString) {
             def (group, name, version) = id.split(':')
             configureDependency(group, name, version, closure)
         }

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/Exclusions.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/Exclusions.groovy
@@ -57,7 +57,7 @@ class Exclusions {
     }
 
     private String getId(def toIdentify) {
-        toIdentify instanceof String ? toIdentify : "$toIdentify.groupId:$toIdentify.artifactId"
+        toIdentify instanceof CharSequence ? toIdentify : "$toIdentify.groupId:$toIdentify.artifactId"
     }
 
     String toString() {


### PR DESCRIPTION
Currently if you try to define dependencies using gstrings like for example:
```
ext.someVersion = "1.0"
dependencyManagement {
    dependencies {
        dependency "someGroup:someName:$someVersion"
    }
}
```
An error occurrs:
```
No such property: group for class: org.codehaus.groovy.runtime.GStringImpl
```
This pull request solves that problem.