### PR TITLE
License plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
+    }
+}
+
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
@@ -5,6 +14,7 @@ apply plugin: 'maven'
 
 apply from: 'gradle-api-source.gradle'
 apply from: 'publish-maven.gradle'
+apply plugin: 'com.github.hierynomus.license'
 
 repositories {
     mavenCentral()
@@ -89,6 +99,17 @@ task javadocJar(type: Jar) {
 artifacts {
     archives sourcesJar
     archives javadocJar
+}
+
+license {
+    header = rootProject.file('gradle/LICENSE_HEADER')
+    strictCheck = true
+    ignoreFailures = true
+    mapping {
+        java   = 'SLASHSTAR_STYLE'
+        groovy = 'SLASHSTAR_STYLE'
+    }
+    ext.year = '2014-2016'
 }
 
 task wrapper(type: Wrapper) {

--- a/gradle/LICENSE_HEADER
+++ b/gradle/LICENSE_HEADER
@@ -1,0 +1,13 @@
+Copyright ${year} the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -11,7 +11,7 @@ install {
                     url = 'http://spring.io'
                 }
                 licenses {
-                    license {
+                    license([:]) { // force evaluation of pretended method, otherwise this node collides with the license plugin
                         name = 'The Apache Software License, Version 2.0'
                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }


### PR DESCRIPTION
This patch applies and configures `hierynomus/license-gradle-plugin`
to keep file headers up to date. The settings can be changed to make
the build fail if a header is missing or non-conformant. For now, all
file headers have been kept untouched.

Run `gradle license` to obtain a report of non-conformant files.
Run `gradle licenseformat` to apply the license template to all files.

Please review the settings found in the `license` block.

Fixes #82 