### PR TITLE
Apply additional metadata on JAR manifest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import java.text.SimpleDateFormat
-
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
@@ -16,14 +14,11 @@ repositories {
 group = 'io.spring.gradle'
 description = 'Dependency Management Plugin'
 
-Date buildTimeAndDate = new Date()
 ext {
     cglibVersion = '3.1'
     jarjarVersion = '1.2.1'
     mavenVersion = '3.0.4'
     spockVersion = GroovySystem.version.startsWith('1.') ? '0.7-groovy-1.8' : '0.7-groovy-2.0'
-    buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
-    buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
 }
 
 sourceCompatibility = 1.7
@@ -80,10 +75,7 @@ jar {
 
     manifest {
         attributes(
-            'Built-By': System.properties['user.name'],
             'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
-            'Build-Date': buildDate,
-            'Build-Time': buildTime,
             'Specification-Title': project.name,
             'Specification-Version': project.version,
             'Specification-Vendor': 'spring.io'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
@@ -14,12 +16,14 @@ repositories {
 group = 'io.spring.gradle'
 description = 'Dependency Management Plugin'
 
+Date buildTimeAndDate = new Date()
 ext {
     cglibVersion = '3.1'
     jarjarVersion = '1.2.1'
     mavenVersion = '3.0.4'
     spockVersion = GroovySystem.version.startsWith('1.') ? '0.7-groovy-1.8' : '0.7-groovy-2.0'
-
+    buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
+    buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
 }
 
 sourceCompatibility = 1.7
@@ -72,6 +76,18 @@ jar {
     from(zipTree(mavenRepackJar.archivePath)) {
         include 'io/spring/gradle/**'
         include 'META-INF/plexus/**'
+    }
+
+    manifest {
+        attributes(
+            'Built-By': System.properties['user.name'],
+            'Created-By': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})".toString(),
+            'Build-Date': buildDate,
+            'Build-Time': buildTime,
+            'Specification-Title': project.name,
+            'Specification-Version': project.version,
+            'Specification-Vendor': 'spring.io'
+        )
     }
 }
 


### PR DESCRIPTION
This patch adds useful metadata to the JAR manifest, such as JDK,
user, build date and time. The SCM hash was omitted as the
`versioning` plugin is not supported by Gradle 1.12. Please consider
a different method to obtain such value _or_ migrate the build
to Gradle 2.x if possible.

Fixes #85 
