### PR TITLE
Don't set version of dependency if the resolved version equals the requested version

### DIFF
--- a/src/main/groovy/io/spring/gradle/dependencymanagement/VersionConfiguringAction.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/VersionConfiguringAction.groovy
@@ -62,7 +62,7 @@ class VersionConfiguringAction implements Action<DependencyResolveDetails> {
         String version = dependencyManagementContainer.
                 getManagedVersion(configuration, details.requested.group,
                         details.requested.name)
-        if (version) {
+        if (version && version != details.requested.version) {
             log.info("Using version '{}' for dependency '{}'", version,
                     details.requested)
             details.useVersion(version)


### PR DESCRIPTION
Allows for multiple resolution strategies to work well with one another. Fixes gh-102