### PR TITLE
Added missing argument for last placeholder in logging message.

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementContainer.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementContainer.java
@@ -131,7 +131,7 @@ public class DependencyManagementContainer {
             if (managedVersion != null) {
                 logger.debug(
                         "Found managed version '{}' for dependency '{}:{}' in dependency "
-                                + "management for configuration '{}'", managedVersion, group, name);
+                                + "management for configuration '{}'", managedVersion, group, name, configuration.getName());
                 return managedVersion;
             }
         }


### PR DESCRIPTION
I have added fourth argument with configuration name that will match fourth placeholder in logging message. Actual configuration name is resolved using ```Configuration::getName``` method.