### PR TITLE
Make output of info level a lot less verbose

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementApplier.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class DependencyManagementApplier implements Action<Configuration> {
 
     @Override
     public void execute(Configuration configuration) {
-        logger.debug("Applying dependency management to configuration '{}' in project '{}'",
+        logger.info("Applying dependency management to configuration '{}' in project '{}'",
                 configuration.getName(), this.project.getName());
 
         final VersionConfiguringAction versionConfiguringAction = new VersionConfiguringAction(

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementApplier.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class DependencyManagementApplier implements Action<Configuration> {
 
     @Override
     public void execute(Configuration configuration) {
-        logger.info("Applying dependency management to configuration '{}' in project '{}'",
+        logger.debug("Applying dependency management to configuration '{}' in project '{}'",
                 configuration.getName(), this.project.getName());
 
         final VersionConfiguringAction versionConfiguringAction = new VersionConfiguringAction(

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/VersionConfiguringAction.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/VersionConfiguringAction.java
@@ -73,7 +73,7 @@ class VersionConfiguringAction implements Action<DependencyResolveDetails> {
                         details.getRequested().getName());
 
         if (version != null) {
-            logger.info("Using version '{}' for dependency '{}'", version,
+            logger.debug("Using version '{}' for dependency '{}'", version,
                     details.getRequested());
             details.useVersion(version);
         }


### PR DESCRIPTION
I ran a build with `--info` using this plugin and the Spring Platform BOM and Spring Cloud Dependencies BOM and noticed a lot of output. I counted the lines produced by these two logging statements. The one in `DependencyManagementApplier` was not as bad, it only produced 74 lines, but the one in `VersionConfiguringAction` produced 1773.

To me it just seems overly chatty and it's not the kind of information I would think people want to see at the info level anyways, but maybe I am wrong.