### PR TITLE
NullPointerException in ProjectPropertySource when a Project has a property with a null value

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/properties/ProjectPropertySource.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/properties/ProjectPropertySource.java
@@ -39,10 +39,10 @@ public class ProjectPropertySource implements PropertySource {
 
     @Override
     public String getProperty(String name) {
-        if (!this.project.hasProperty(name)) {
-            return null;
+        if (this.project.hasProperty(name) && this.project.property(name) != null) {
+            return this.project.property(name).toString();
         }
-        return this.project.property(name).toString();
+        return null;
     }
 
 }


### PR DESCRIPTION
I got at an NPE when switching from 1.5.9.RELEASE to 1.5.10.RELEASE 

Fixes #206

Ref.

```
Caused by: java.lang.NullPointerException
        at io.spring.gradle.dependencymanagement.internal.properties.ProjectPropertySource.getProperty(ProjectPropertySource.java:45)
        at io.spring.gradle.dependencymanagement.internal.properties.ProjectPropertySource.getProperty(ProjectPropertySource.java:27)
        at io.spring.gradle.dependencymanagement.internal.properties.CompositePropertySource.getProperty(CompositePropertySource.java:43)
```