### PR TITLE
#224 support standard Gradle dependency notation in "importPom"

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/dsl/ImportsHandler.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/dsl/ImportsHandler.java
@@ -28,29 +28,29 @@ import org.gradle.api.Action;
 public interface ImportsHandler {
 
     /**
-     * Imports the Maven bom with the given {@code coordinates} in the form {@code group:name:version}.
+     * Imports the Maven bom with the given {@code dependencyNotation}.
      *
-     * @param coordinates the bom's coordinates
+     * @param dependencyNotation the bom's dependency notation
      */
-    void mavenBom(String coordinates);
+    void mavenBom(Object dependencyNotation);
 
     /**
-     * Imports the Maven bom with the given {@code coordinates} in the form {@code group:name:version}. The import
-     * is customized using the given {@code closure} which is called with a {@link MavenBomHandler} as its delegate.
+     * Imports the Maven bom with the given {@code dependencyNotation}. The import is customized using the given
+     * {@code closure} which is called with a {@link MavenBomHandler} as its delegate.
      *
-     * @param coordinates the bom's coordinates
+     * @param dependencyNotation the bom's dependency notation
      * @param closure the closure
      * @see MavenBomHandler
      */
-    void mavenBom(String coordinates, Closure closure);
+    void mavenBom(Object dependencyNotation, Closure closure);
 
     /**
-     * Imports the Maven bom with the given {@code coordinates} in the form {@code group:name:version}. The import
+     * Imports the Maven bom with the given {@code dependencyNotation}. The import
      * is customized using the given {@code action}.
      *
-     * @param coordinates the bom's coordinates
+     * @param dependencyNotation the bom's dependency notation
      * @param action the action
      */
-    void mavenBom(String coordinates, Action<MavenBomHandler> action);
+    void mavenBom(Object dependencyNotation, Action<MavenBomHandler> action);
 
 }

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagement.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagement.java
@@ -76,8 +76,8 @@ public class DependencyManagement {
         this.targetConfiguration = targetConfiguration;
     }
 
-    void importBom(Coordinates coordinates, PropertySource properties) {
-        this.importedBoms.add(new PomReference(coordinates, properties));
+    void importBom(Object dependencyNotation, PropertySource properties) {
+        this.importedBoms.add(new PomReference(dependencyNotation, properties));
     }
 
     /**

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementContainer.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagementContainer.java
@@ -97,16 +97,16 @@ public class DependencyManagementContainer {
 
     /**
      * Adds an import of a bom to the dependency management for the given {@code configuration}. The bom is
-     * identified by the given {@code coordinates} and the given {@code properties} will be used when resolving the
-     * bom's contents.
+     * identified by the given {@code dependencyNotation} and the given {@code properties} will be used when resolving
+     * the bom's contents.
      *
      * @param configuration the configuration
-     * @param coordinates the coordinates of the bom
+     * @param dependencyNotation the dependency notation of the bom
      * @param properties the properties to use when resolving the bom's contents
      */
-    public void importBom(Configuration configuration, Coordinates coordinates,
+    public void importBom(Configuration configuration, Object dependencyNotation,
             PropertySource properties) {
-        dependencyManagementForConfiguration(configuration).importBom(coordinates, properties);
+        dependencyManagementForConfiguration(configuration).importBom(dependencyNotation, properties);
     }
 
     String getManagedVersion(Configuration configuration, String group, String name) {

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardImportsHandler.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardImportsHandler.java
@@ -17,6 +17,7 @@
 package io.spring.gradle.dependencymanagement.internal.dsl;
 
 import groovy.lang.Closure;
+import groovy.lang.GString;
 import groovy.lang.GroovyObjectSupport;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -44,13 +45,13 @@ class StandardImportsHandler extends GroovyObjectSupport implements ImportsHandl
     }
 
     @Override
-    public void mavenBom(String coordinates) {
-        this.mavenBom(coordinates, (Action<MavenBomHandler>) null);
+    public void mavenBom(Object dependencyNotation) {
+        this.mavenBom(dependencyNotation, (Action<MavenBomHandler>) null);
     }
 
     @Override
-    public void mavenBom(String coordinates, final Closure closure) {
-        mavenBom(coordinates, new Action<MavenBomHandler>() {
+    public void mavenBom(Object dependencyNotation, final Closure closure) {
+        mavenBom(dependencyNotation, new Action<MavenBomHandler>() {
 
             @Override
             public void execute(MavenBomHandler mavenBomHandler) {
@@ -64,17 +65,19 @@ class StandardImportsHandler extends GroovyObjectSupport implements ImportsHandl
     }
 
     @Override
-    public void mavenBom(String coordinates, Action<MavenBomHandler> action) {
+    public void mavenBom(Object dependencyNotation, Action<MavenBomHandler> action) {
         StandardMavenBomHandler mavenBomHandler = new StandardMavenBomHandler();
         if (action != null) {
             action.execute(mavenBomHandler);
         }
-        String[] components = coordinates.split(":");
-        if (components.length != 3) {
-            throw new IllegalArgumentException("Bom coordinates must be of the form groupId:artifactId:version");
+        if (dependencyNotation instanceof String || dependencyNotation instanceof GString) {
+            String[] components = dependencyNotation.toString().split(":");
+            if (components.length != 3) {
+                throw new IllegalArgumentException("Bom coordinates must be of the form groupId:artifactId:version");
+            }
+            dependencyNotation = new Coordinates(components[0], components[1], components[2]);
         }
-        this.container.importBom(this.configuration, new Coordinates(components[0], components[1], components[2]),
-                mavenBomHandler.getBomProperties());
+        this.container.importBom(this.configuration, dependencyNotation, mavenBomHandler.getBomProperties());
     }
 
 

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/pom/PomReference.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/pom/PomReference.java
@@ -28,7 +28,7 @@ import io.spring.gradle.dependencymanagement.internal.properties.PropertySource;
  */
 public final class PomReference {
 
-    private final Coordinates coordinates;
+    private final Object dependencyNotation;
 
     private final PropertySource properties;
 
@@ -44,21 +44,27 @@ public final class PomReference {
     /**
      * Creates a new {@code PomReference}.
      *
-     * @param coordinates the coordinates of the referenced pom
+     * @param dependencyNotation the dependency notation of the referenced pom
      * @param properties the properties that should be used when resolving the pom's contents
      */
-    public PomReference(Coordinates coordinates, PropertySource properties) {
-        this.coordinates = coordinates;
+    public PomReference(Object dependencyNotation, PropertySource properties) {
+        if (dependencyNotation instanceof Coordinates) {
+            Coordinates coordinates = (Coordinates) dependencyNotation;
+            this.dependencyNotation = coordinates.getGroupId() + ":" + coordinates.getArtifactId() + ":"
+                    + coordinates.getVersion() + "@pom";
+        } else {
+            this.dependencyNotation = dependencyNotation;
+        }
         this.properties = properties;
     }
 
     /**
-     * Returns the coordinates of the referenced pom.
+     * Returns the dependency notation of the referenced pom.
      *
      * @return the coordinates
      */
-    public Coordinates getCoordinates() {
-        return this.coordinates;
+    public Object getDependencyNotation() {
+        return dependencyNotation;
     }
 
     /**


### PR DESCRIPTION
This solves #224 and also makes it possible to import POMs from any valid Gradle dependency notation (`group: "", artifact: "", version: ""`, `project.files()`, `fromURL`, etc)