### PR TITLE
Link directly to the new reference documentation from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ license][7].
 
 [1]: https://badges.gitter.im/Join%20Chat.svg
 [2]: https://gitter.im/spring-gradle-plugins/dependency-management-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
-[3]: https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/
+[3]: https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html5/
 [4]: CODE_OF_CONDUCT.md
 [5]: https://help.github.com/articles/using-pull-requests/
 [6]: CONTRIBUTING.md


### PR DESCRIPTION
Currently, link to reference documentation in project's readme leads to directory listing at https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/. This is inconvenient as it forces users to click an additional link in order to access the docs.