### PR TITLE
URL Cleanup

### DIFF
--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -5,15 +5,15 @@ install {
             generatedPom.project {
                 name = 'Dependency management plugin'
                 description = 'A Gradle plugin that provides Maven-like dependency management functionality'
-                url = 'http://github.com/spring-gradle-plugins/dependency-management-plugin'
+                url = 'https://github.com/spring-gradle-plugins/dependency-management-plugin'
                 organization {
                     name = 'Pivotal Software, Inc.'
-                    url = 'http://spring.io'
+                    url = 'https://spring.io'
                 }
                 licenses {
                     license {
                         name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
                 scm {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://docs.groovy-lang.org/ (200) could not be migrated:  
   ([https](https://docs.groovy-lang.org/) result SSLProtocolException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/spring-gradle-plugins/dependency-management-plugin migrated to:  
  https://github.com/spring-gradle-plugins/dependency-management-plugin ([https](https://github.com/spring-gradle-plugins/dependency-management-plugin) result 200).
* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).