### PR TITLE
URL Cleanup

### DIFF
--- a/ci/integration-test.sh
+++ b/ci/integration-test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-curl --silent --output gradle.zip -L http://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip
+curl --silent --output gradle.zip -L https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip
 unzip -qq gradle.zip
 cd dependency-management-plugin
 export GRADLE_OPTS=-Dorg.gradle.native=false

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -5,15 +5,15 @@ install {
             generatedPom.project {
                 name = 'Dependency management plugin'
                 description = 'A Gradle plugin that provides Maven-like dependency management functionality'
-                url = 'http://github.com/spring-gradle-plugins/dependency-management-plugin'
+                url = 'https://github.com/spring-gradle-plugins/dependency-management-plugin'
                 organization {
                     name = 'Pivotal Software, Inc.'
-                    url = 'http://spring.io'
+                    url = 'https://spring.io'
                 }
                 licenses {
                     license {
                         name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
                 scm {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://services.gradle.org/distributions/gradle- (404) with 1 occurrences migrated to:  
  https://services.gradle.org/distributions/gradle- ([https](https://services.gradle.org/distributions/gradle-) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/spring-gradle-plugins/dependency-management-plugin with 1 occurrences migrated to:  
  https://github.com/spring-gradle-plugins/dependency-management-plugin ([https](https://github.com/spring-gradle-plugins/dependency-management-plugin) result 200).
* http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).