### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,5 +668,5 @@ Dependency Management Plugin is open source software released under the [Apache 
 [9]: CODE_OF_CONDUCT.md
 [10]: https://help.github.com/articles/using-pull-requests/
 [11]: CONTRIBUTING.md
-[12]: http://www.apache.org/licenses/LICENSE-2.0.html
+[12]: https://www.apache.org/licenses/LICENSE-2.0.html
 

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/CompoundDependencyManagementHandler.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/CompoundDependencyManagementHandler.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependenciesHandler.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependenciesHandler.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagement.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagement.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementConfigurationContainer.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementConfigurationContainer.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementContainer.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementContainer.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementExtension.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementExtension.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementHandler.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementHandler.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/DependencyManagementPlugin.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/ImportsHandler.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/ImportsHandler.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/VersionConfiguringAction.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/VersionConfiguringAction.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/Versions.java
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/Versions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/ExclusionConfiguringAction.java
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/ExclusionConfiguringAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/ExclusionResolver.java
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/ExclusionResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/Exclusions.java
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/exclusions/Exclusions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/maven/ModelExclusionCollector.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/maven/ModelExclusionCollector.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/maven/PomDependencyManagementConfigurer.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/maven/PomDependencyManagementConfigurer.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/maven/PomDependencyModelResolver.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/maven/PomDependencyModelResolver.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/maven/RelaxedModelValidator.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/maven/RelaxedModelValidator.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportRenderer.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportRenderer.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportTask.groovy
+++ b/src/main/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportTask.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/groovy/io/spring/gradle/dependencymanagement/DependencyManagementPluginSpec.groovy
+++ b/src/test/groovy/io/spring/gradle/dependencymanagement/DependencyManagementPluginSpec.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/groovy/io/spring/gradle/dependencymanagement/maven/PomDependencyManagementConfigurerSpec.groovy
+++ b/src/test/groovy/io/spring/gradle/dependencymanagement/maven/PomDependencyManagementConfigurerSpec.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportRendererSpec.groovy
+++ b/src/test/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportRendererSpec.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportTaskSpec.groovy
+++ b/src/test/groovy/io/spring/gradle/dependencymanagement/report/DependencyManagementReportTaskSpec.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 24 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).