### PR TITLE
Improve performance when applying maven exclusions.

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionResolver.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionResolver.java
@@ -45,8 +45,6 @@ class ExclusionResolver {
     private static final Set<String> IGNORED_SCOPES = Collections
             .unmodifiableSet(new HashSet<String>(Arrays.asList("provided", "test")));
 
-    private final Map<String, Exclusions> exclusionsCache = new HashMap<String, Exclusions>();
-
     private final PomResolver pomResolver;
 
     ExclusionResolver(PomResolver pomResolver) {
@@ -64,7 +62,7 @@ class ExclusionResolver {
                     .getName() != null) {
                 String id = resolvedComponent.getModuleVersion()
                         .getGroup() + ":" + resolvedComponent.getModuleVersion().getName();
-                Exclusions exclusions = this.exclusionsCache.get(id);
+                Exclusions exclusions = ExclusionsCache.get(id);
                 if (exclusions != null) {
                     exclusionsById.put(id, exclusions);
                 }
@@ -79,7 +77,7 @@ class ExclusionResolver {
         for (Pom pom: poms) {
             String id = pom.getCoordinates().getGroupId() + ":" + pom.getCoordinates().getArtifactId();
             Exclusions exclusions = collectExclusions(pom);
-            this.exclusionsCache.put(id, exclusions);
+            ExclusionsCache.put(id, exclusions);
             exclusionsById.put(id, exclusions);
         }
         return exclusionsById;

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionsCache.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionsCache.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.gradle.dependencymanagement.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Shared cache for found exclusions.
+ *
+ * @author Tom Briers
+ */
+final class ExclusionsCache {
+    private static final Map<String, Exclusions> exclusionsCache = new HashMap<String, Exclusions>();
+
+    private ExclusionsCache() {
+
+    }
+
+    static Exclusions get(String id) {
+        return exclusionsCache.get(id);
+    }
+
+    static Exclusions put(String id, Exclusions exclusions) {
+        return exclusionsCache.put(id, exclusions);
+    }
+}


### PR DESCRIPTION
Hi,

We using maven exclusions we found that the performance of resolving the dependencies was very poor.  
After investigating this a bit I found that for each set of dependencies that needs to be calculated the plugin starts with an empty cache.  Adding a 'plugin wide' cache for the already collected exclusions seems to improve performance quiet a bit.

Regards,

Tom.