### PR TITLE
Cache POM exclusions in Gradle daemon

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/Exclusions.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/Exclusions.java
@@ -32,6 +32,11 @@ class Exclusions {
     private final Map<String, Set<String>> exclusionsByDependency = new HashMap<String, Set<String>>();
 
     void add(String dependency, Collection<String> exclusionsForDependency) {
+        // Most dependencies will have no exclusions, so avoid bloating this container with empty hashmaps.
+        if (exclusionsForDependency.isEmpty()) {
+            return;
+        }
+
         Set<String> exclusions = this.exclusionsByDependency.get(dependency);
         if (exclusions == null) {
             exclusions = new HashSet<String>();
@@ -47,7 +52,8 @@ class Exclusions {
     }
 
     Set<String> exclusionsForDependency(String dependency) {
-        return this.exclusionsByDependency.get(dependency);
+        Set<String> result = this.exclusionsByDependency.get(dependency);
+        return result == null ? new HashSet<String>() : result;
     }
 
     @Override


### PR DESCRIPTION
In many of our spring projects dependency resolution is the slowest link in the edit-compile-test cycle, ranging between ~1.5 to ~6 seconds in the worst case.

Instrumenting the slowest of our multi-project builds I noticed that over 1,700 Pom files are parsed during dependency resolution, with some POMS being parsed many times over.

This change introduces a static POM exclusion cache, which reduces dependency resolution to less than a second on subsequent builds in that same project.