### PR TITLE
High CPU usage when identifying local projects in large multi-project builds

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/VersionConfiguringAction.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/VersionConfiguringAction.java
@@ -45,6 +45,8 @@ class VersionConfiguringAction implements Action<DependencyResolveDetails> {
 
     private Set<String> directDependencies;
 
+    private Set<String> localProjectNames;
+
     VersionConfiguringAction(Project project,
                              DependencyManagementContainer dependencyManagementContainer,
                              Configuration configuration) {
@@ -97,16 +99,15 @@ class VersionConfiguringAction implements Action<DependencyResolveDetails> {
 
     private boolean isDependencyOnLocalProject(Project project,
                                                DependencyResolveDetails details) {
-        return getAllLocalProjectNames(project.getRootProject()).contains(details.getRequested()
-                .getGroup() + ":" + details.getRequested().getName());
-    }
-
-    private Set<String> getAllLocalProjectNames(Project rootProject) {
-        Set<String> names = new HashSet<String>();
-        for (Project localProject: rootProject.getAllprojects()) {
-            names.add(localProject.getGroup() + ":" + localProject.getName());
+        if (this.localProjectNames == null) {
+            Set<String> names = new HashSet<String>();
+            for (Project localProject : project.getRootProject().getAllprojects()) {
+                names.add(localProject.getGroup() + ":" + localProject.getName());
+            }
+            this.localProjectNames = names;
         }
-        return names;
-    }
 
+        return localProjectNames
+                .contains(details.getRequested().getGroup() + ":" + details.getRequested().getName());
+    }
 }


### PR DESCRIPTION
I noticed that adding spring-boot-dependency plugin makes IntelliJ gradle project reloading longer.

In summary, I found 2 major reason.

* Apply maven execution rule is heavy task. (I have no idea now about how to improve it)
* [VersionConfiguringAction.isDependencyOnLocalProject](https://github.com/spring-gradle-plugins/dependency-management-plugin/blob/master/src/main/java/io/spring/gradle/dependencymanagement/internal/VersionConfiguringAction.java#L98-L110) calls Gradle's `.getAllprojects()` and it's not optimized for frequent call.

(I wrote some things in https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/288)

This PR introduces a cache of local project names.
(This is the same thing of already done for `directDependencies` https://github.com/spring-gradle-plugins/dependency-management-plugin/blame/master/src/main/java/io/spring/gradle/dependencymanagement/internal/VersionConfiguringAction.java#L86-L96)

This value must be the same in project global but caching it in `VersionConfiguringAction` is enough for performance.

AS-IS: `.getAllprojects()` called every `project x configuration x dependency`
TO-BE: `.getAllprojects()` called every `project x configuration` (I'm not sure about this)

Profiler result (n = 1)
-----
Condition:
* large scale project (modules > 200 & configurations ~ 50 because of applied many plugins)
* But set `setApplyMavenExclusions(false)` for fast configuration reload.

x | Total samples profiler | isDependencyOnLocalProject | ex isDependencyOnLocalProject (calculated) | Reload time on my machine | 
------------ | ------------- | ------------- | ------------- | ------------- 
Before | 25,460 |  12,540 | 12,920 | 41s
After | 13,042 (-49%) | 177 | 12,865 | 21s

Frame graph / Before
----

![image](https://user-images.githubusercontent.com/1370068/103123234-fe5e6480-46c6-11eb-9f45-f10c38577177.png)


Frame graph / After
----

![image](https://user-images.githubusercontent.com/1370068/103124106-04097980-46ca-11eb-929c-01133ad4160d.png)
