### PR TITLE
Remove duplicate String-based dependency management declaration from Map-based Kotlin example

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -159,7 +159,6 @@ dependencyManagement {
 ----
 dependencyManagement {
     dependencies {
-        dependency("org.springframework:spring-core:4.0.3.RELEASE")
         dependency(mapOf(
             "group" to "org.springframework",
             "name" to "spring-core",


### PR DESCRIPTION
I found the duplicated code while executing the example code of the document.
From the context, It looks like `dependency("org.springframework:spring-core:4.0.3.RELEASE")` should be removed.