### PR TITLE
Pom customization has unwanted side-effect of reversing bom import ordering

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
@@ -39,6 +39,7 @@ import org.gradle.api.XmlProvider;
  * Standard implementation of {@link PomDependencyManagementConfigurer}.
  *
  * @author Andy Wilkinson
+ * @author Rupert Waldron
  */
 public class StandardPomDependencyManagementConfigurer implements PomDependencyManagementConfigurer {
 

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
@@ -144,8 +144,11 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 			appendDependencyNode(dependencies, override.getCoordinates(), override.getScope(), override.getType());
 		}
 		List<PomReference> importedBoms = this.dependencyManagement.getImportedBomReferences();
-		Collections.reverse(importedBoms);
-		for (PomReference resolvedBom : importedBoms) {
+
+		List<PomReference> importedBomsCopy = new ArrayList<>(importedBoms);
+		Collections.reverse(importedBomsCopy);
+
+		for (PomReference resolvedBom : importedBomsCopy) {
 			addImport(dependencies, resolvedBom);
 		}
 	}

--- a/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link DependencyManagementPlugin}.
  *
  * @author Andy Wilkinson
+ * @author Rupert Waldron
  */
 class DependencyManagementPluginIntegrationTests {
 

--- a/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
@@ -337,6 +337,12 @@ class DependencyManagementPluginIntegrationTests {
 	}
 
 	@Test
+	void bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished() {
+		this.gradleBuild.runner().withArguments("managedVersionsAfterPublishPom").build();
+		assertThat(readLines("managed-versions.txt")).contains("org.springframework:spring-core -> 4.2.3.RELEASE");
+	}
+
+	@Test
 	void managedVersionsOfAConfigurationCanBeAccessed() {
 		this.gradleBuild.runner().withArguments("verify").build();
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished.gradle
@@ -1,0 +1,40 @@
+plugins {
+	id "io.spring.dependency-management"
+	id "java"
+	id 'maven-publish'
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencyManagement {
+	imports {
+		mavenBom 'org.springframework.boot:spring-boot-dependencies:1.2.7.RELEASE'
+		mavenBom 'io.spring.platform:platform-bom:2.0.0.RELEASE'
+	}
+}
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			groupId = 'group-id'
+			artifactId = 'dep-management'
+			version = '1.0'
+
+			from components.java
+		}
+	}
+}
+
+
+task managedVersionsAfterPublishPom {
+	dependsOn generatePomFileForMavenPublication
+	doFirst {
+		def output = new File("${buildDir}/managed-versions.txt")
+		output.parentFile.mkdirs()
+		dependencyManagement.managedVersions.each { key, value ->
+			output << "${key} -> ${value}\n"
+		}
+	}
+}


### PR DESCRIPTION
We found an issue at work whereby we were importing several boms in order and creating two jars, one for code and one for libraries. Our jenkins pipeline then publishes the artifacts but the task still builds the library jar (our pipeline doesn't expect two jars). We noticed that this jar had different library version to the one that we created earlier in the pipeline. 

So after a day or so of debugging we found that if we publish a Pom then the ordering of the imports is reversed so we get different versions. This is caused by `Collections.reverse(importedBoms)` in StandardPomDependencyManagementConfigurer which reverses the original list so dependencies end up in the reverse order. I just fixed this by taking a copy of the original list. Test added to.