### PR TITLE
Exclusions are calculated unnecessarily for non-transitive configurations

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionConfiguringAction.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionConfiguringAction.java
@@ -96,6 +96,9 @@ class ExclusionConfiguringAction implements Action<ResolvableDependencies> {
 	}
 
 	private Set<DependencyCandidate> findExcludedDependencies() {
+		if (!this.configuration.isTransitive()) {
+			return Collections.emptySet();
+		}
 		ResolutionResult resolutionResult = copyConfiguration().getIncoming().getResolutionResult();
 		ResolvedComponentResult root = resolutionResult.getRoot();
 		Set<DependencyCandidate> excludedDependencies = new HashSet<>();


### PR DESCRIPTION
All direct dependencies of a configuration are included by default and all other are excluded by default for non transitive configurations. It is therefore unnecessary to calculate exclusions.