### PR TITLE
Some gradle build-related updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,19 +4,13 @@ plugins {
 	id 'java-gradle-plugin'
 	id 'maven-publish'
 
-	id 'io.spring.javaformat' version '0.0.39'
-	id 'io.spring.nohttp' version '0.0.10'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	alias(libs.plugins.asciidoctor)
+	alias(libs.plugins.javaformat)
+	alias(libs.plugins.nohttp)
 }
 
 group = 'io.spring.gradle'
 description = 'Dependency Management Plugin'
-
-ext {
-	cglibVersion = '3.1'
-	jarjarVersion = '1.2.1'
-	mavenVersion = '3.8.7'
-}
 
 repositories {
 	mavenCentral()
@@ -35,7 +29,7 @@ gradlePlugin {
 }
 
 checkstyle {
-	configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+	configFile = layout.projectDirectory.file("config/checkstyle/checkstyle.xml").asFile
 	configProperties = [ 'checkstyle.config.dir' : rootProject.file('config/checkstyle') ]
 }
 
@@ -47,7 +41,7 @@ configurations {
 
 def mavenRepackJar = tasks.register("mavenRepackJar", Jar) { repackJar ->
 	repackJar.archiveBaseName = "maven-repack"
-	repackJar.archiveVersion = mavenVersion
+	repackJar.archiveVersion = libs.versions.maven.get()
 
 	doLast() {
 		project.ant {
@@ -63,26 +57,26 @@ def mavenRepackJar = tasks.register("mavenRepackJar", Jar) { repackJar ->
 }
 
 dependencies {
-	asciidoctorExt 'io.spring.asciidoctor.backends:spring-asciidoctor-backends:0.0.4'
+	asciidoctorExt libs.spring.asciidoctor.backends
 
-	checkstyle 'io.spring.javaformat:spring-javaformat-checkstyle:0.0.39'
+	checkstyle libs.spring.javaformat.checkstyle
 
 	implementation(files(mavenRepackJar))
 
-	jarjar "org.gradle.jarjar:jarjar:$jarjarVersion"
+	jarjar libs.jarjar
 
-	maven "org.apache.maven:maven-model-builder:$mavenVersion"
+	maven libs.maven.model.builder
 
-	testImplementation "cglib:cglib-nodep:$cglibVersion"
-	testImplementation "org.assertj:assertj-core:3.23.1"
-	testImplementation "org.mockito:mockito-core:4.6.1"
-	testImplementation "org.junit.jupiter:junit-jupiter:5.8.2"
+	testImplementation libs.cglib.nodep
+	testImplementation libs.assertj.core
+	testImplementation libs.mockito.core
+	testImplementation libs.junit.jupiter
 }
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
-
 java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(8)
+	}
 	withJavadocJar()
 	withSourcesJar()
 }
@@ -133,7 +127,7 @@ tasks.register("docsZip", Zip) {
 	archiveBaseName = 'dependency-management-plugin'
 	archiveClassifier = 'docs'
 	description = "Builds docs archive containing API and reference documentation"
-	destinationDirectory = file("${project.buildDir}/distributions")
+	destinationDirectory = layout.buildDirectory.dir("distributions")
 
 	from(tasks.named("asciidoctor")) {
 		into 'reference/html'
@@ -144,7 +138,7 @@ tasks.register("docsZip", Zip) {
 }
 
 publishing {
-	publications.all {
+	publications.configureEach {
 		pom {
 			name = 'Dependency management plugin'
 			description = 'A Gradle plugin that provides Maven-like dependency management functionality'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,19 @@
+[versions]
+maven = "3.8.7"
+
+[libraries]
+assertj-core = { module = "org.assertj:assertj-core", version = "3.23.1" }
+cglib-nodep = { module = "cglib:cglib-nodep", version = "3.1" }
+jarjar = { module = "org.gradle.jarjar:jarjar", version = "1.2.1" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.8.2" }
+spring-asciidoctor-backends = { module = "io.spring.asciidoctor.backends:spring-asciidoctor-backends", version = "0.0.4" }
+spring-javaformat-checkstyle = { module = "io.spring.javaformat:spring-javaformat-checkstyle", version = "0.0.39" }
+maven-model-builder = { module = "org.apache.maven:maven-model-builder", version.ref = "maven" }
+mockito-core = { module = "org.mockito:mockito-core", version = "4.6.1" }
+
+[bundles]
+
+[plugins]
+asciidoctor = { id = "org.asciidoctor.jvm.convert", version = "3.3.2" }
+javaformat = { id = "io.spring.javaformat", version = "0.0.39" }
+nohttp = { id = "io.spring.nohttp", version = "0.0.10" }


### PR DESCRIPTION
- Created version catalog file and migrated plugins, modules, versions to it
- Removed ext block as versions are now defined in version catalog
- Replaced source/target compatibility with toolchain
- Switched a couple of file/dir references to use layout API
- Changing publications to use configurations.configureEach instead of all