### PR TITLE
PoC: The Configuration Cache Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'maven-publish'
 
 	id 'io.spring.javaformat' version '0.0.39'
-	id 'io.spring.nohttp' version '0.0.10'
+	id 'io.spring.nohttp' version '0.0.11'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/spring/gradle/dependencymanagement/DependencyManagementPlugin.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/DependencyManagementPlugin.java
@@ -46,10 +46,12 @@ public class DependencyManagementPlugin implements Plugin<Project> {
 
 	private void configurePomCustomization(Project project,
 			DependencyManagementExtension dependencyManagementExtension) {
-		PomDependencyManagementConfigurer pomConfigurer = dependencyManagementExtension.getPomConfigurer();
-		project.getPlugins()
-			.withType(MavenPublishPlugin.class,
-					(mavenPublishPlugin) -> configurePublishingExtension(project, pomConfigurer));
+		project.afterEvaluate((evaluatedProject) -> {
+			PomDependencyManagementConfigurer pomConfigurer = dependencyManagementExtension.getPomConfigurer();
+			evaluatedProject.getPlugins()
+				.withType(MavenPublishPlugin.class,
+						(mavenPublishPlugin) -> configurePublishingExtension(evaluatedProject, pomConfigurer));
+		});
 	}
 
 	private void configurePublishingExtension(Project project, PomDependencyManagementConfigurer extension) {

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagement.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagement.java
@@ -80,7 +80,11 @@ public class DependencyManagement {
 		this.importedBoms.add(new PomReference(coordinates, properties));
 	}
 
-	List<PomReference> getImportedBomReferences() {
+	/**
+	 * Returns the imported bom references.
+	 * @return the imported bom references
+	 */
+	public List<PomReference> getImportedBomReferences() {
 		return Collections.unmodifiableList(this.importedBoms);
 	}
 
@@ -125,6 +129,15 @@ public class DependencyManagement {
 		return managedDependencies;
 	}
 
+	/**
+	 * Returns the resolved boms.
+	 * @param propertySource the property source
+	 * @return the resolved boms
+	 */
+	public List<Pom> getResolvedBoms(PropertySource propertySource) {
+		return this.pomResolver.resolvePoms(this.importedBoms, propertySource);
+	}
+
 	private String createKey(String group, String name) {
 		return group + ":" + name;
 	}
@@ -166,9 +179,7 @@ public class DependencyManagement {
 		}
 		Map<String, String> existingVersions = new LinkedHashMap<>(this.versions);
 		logger.debug("Preserving existing versions: {}", existingVersions);
-		List<Pom> resolvedBoms = this.pomResolver.resolvePoms(this.importedBoms,
-				new ProjectPropertySource(this.project));
-		for (Pom resolvedBom : resolvedBoms) {
+		for (Pom resolvedBom : getResolvedBoms(new ProjectPropertySource(this.project))) {
 			for (Dependency dependency : resolvedBom.getManagedDependencies()) {
 				resolve(resolvedBom, dependency);
 			}

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardDependencyManagementExtension.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardDependencyManagementExtension.java
@@ -17,6 +17,7 @@
 package io.spring.gradle.dependencymanagement.internal.dsl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,12 +29,14 @@ import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension;
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementHandler;
 import io.spring.gradle.dependencymanagement.dsl.GeneratedPomCustomizationHandler;
 import io.spring.gradle.dependencymanagement.dsl.ImportsHandler;
+import io.spring.gradle.dependencymanagement.internal.DependencyManagement;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementConfigurationContainer;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementContainer;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementSettings;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementSettings.PomCustomizationSettings;
 import io.spring.gradle.dependencymanagement.internal.StandardPomDependencyManagementConfigurer;
-import io.spring.gradle.dependencymanagement.internal.maven.MavenPomResolver;
+import io.spring.gradle.dependencymanagement.internal.properties.MapPropertySource;
+import io.spring.gradle.dependencymanagement.internal.properties.ProjectPropertySource;
 import org.codehaus.groovy.runtime.ReflectionMethodInvoker;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -139,10 +142,12 @@ public class StandardDependencyManagementExtension extends GroovyObjectSupport
 
 	@Override
 	public StandardPomDependencyManagementConfigurer getPomConfigurer() {
-		return new StandardPomDependencyManagementConfigurer(
-				this.dependencyManagementContainer.getGlobalDependencyManagement(),
-				this.dependencyManagementSettings.getPomCustomizationSettings(),
-				new MavenPomResolver(this.project, this.configurationContainer), this.project);
+		DependencyManagement dependencyManagement = this.dependencyManagementContainer.getGlobalDependencyManagement();
+		return new StandardPomDependencyManagementConfigurer(dependencyManagement.getManagedDependencies(),
+				dependencyManagement.getImportedBomReferences(),
+				dependencyManagement.getResolvedBoms(new MapPropertySource(Collections.emptyMap())),
+				dependencyManagement.getResolvedBoms(new ProjectPropertySource(this.project)),
+				this.dependencyManagementSettings.getPomCustomizationSettings());
 	}
 
 	/**

--- a/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
@@ -26,10 +26,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests for {@link DependencyManagementPlugin}.
@@ -552,6 +554,12 @@ class DependencyManagementPluginIntegrationTests {
 			.withArguments("dependencies", "--configuration", "nonTransitive")
 			.build();
 		assertThat(result.getOutput()).doesNotContain("Error");
+	}
+
+	@Test
+	void violationOfConfigurationCache() {
+		assertThatThrownBy(() -> this.gradleBuild.runner().withArguments("violate").build())
+			.isInstanceOf(UnexpectedBuildFailure.class);
 	}
 
 	private void writeLines(Path path, String... lines) {

--- a/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
@@ -182,11 +182,26 @@ class DependencyManagementPluginIntegrationTests {
 	@Test
 	void managedVersionsCanBeAccessedProgramatically() {
 		this.gradleBuild.runner().withArguments("verify").build();
+		assertThat(readLines("implementation-managed-versions.txt"))
+			.contains("org.springframework:spring-core -> 4.0.6.RELEASE", "com.alpha:bravo -> 1.0",
+					"com.alpha:charlie -> 1.0")
+			.doesNotContain("com.foo:bar");
+		assertThat(readLines("testRuntimeOnly-managed-versions.txt"))
+			.contains("org.springframework:spring-core -> 4.0.6.RELEASE", "com.foo:bar -> 1.2.3",
+					"com.alpha:bravo -> 1.0", "com.alpha:charlie -> 1.0")
+			.doesNotContain("com.foo:bar");
+		assertThat(readLines("managed-versions.txt"))
+			.contains("org.springframework:spring-core -> 4.0.6.RELEASE", "com.alpha:bravo -> 1.0",
+					"com.alpha:charlie -> 1.0")
+			.doesNotContain("com.foo:bar");
 	}
 
 	@Test
 	void propertiesImportedFromABomCanBeAccessed() {
 		this.gradleBuild.runner().withArguments("verify").build();
+		assertThat(readLines("imported-properties.txt")).contains("hibernate.version -> 4.3.5.Final");
+		assertThat(readLines("myConfiguration-imported-properties.txt")).contains("spring.version -> 4.1.4.RELEASE",
+				"jruby.version -> 1.7.12");
 	}
 
 	@Test
@@ -347,6 +362,7 @@ class DependencyManagementPluginIntegrationTests {
 	@Test
 	void managedVersionsOfAConfigurationCanBeAccessed() {
 		this.gradleBuild.runner().withArguments("verify").build();
+		assertThat(readLines("managed-versions.txt")).contains("org.springframework:spring-core -> 4.1.8.RELEASE");
 	}
 
 	@Test

--- a/src/test/java/io/spring/gradle/dependencymanagement/GradleBuild.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/GradleBuild.java
@@ -63,6 +63,7 @@ public class GradleBuild implements BeforeEachCallback {
 			throw new IllegalStateException("No build script found for " + testClass.getName() + " " + methodName);
 		}
 		Files.copy(input, project.dir.resolve("build.gradle"));
+		Files.copy(testClass.getResourceAsStream("/gradle.properties"), project.dir.resolve("gradle.properties"));
 		copyRecursively(Paths.get("src", "test", "resources", "maven-repo"), project.dir.resolve("maven-repo"));
 	}
 

--- a/src/test/java/io/spring/gradle/dependencymanagement/GradleVersionCompatibilityIntegrationTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/GradleVersionCompatibilityIntegrationTests.java
@@ -64,7 +64,7 @@ class GradleVersionCompatibilityIntegrationTests {
 
 	static List<String[]> gradleVersions() {
 		List<String> versions = Arrays.asList("6.8.3", "6.9.4", "7.0.2", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1",
-				"8.0.2", "8.1.1", "8.2.1", "8.3", "8.4", "8.5", "8.6", "8.7", "8.8");
+				"8.0.2", "8.1.1", "8.2.1", "8.3", "8.4", "8.5", "8.6", "8.7", "8.8", "8.9");
 		List<String[]> result = new ArrayList<>();
 		for (String version : versions) {
 			result.add(new String[] { version });

--- a/src/test/resources/gradle.properties
+++ b/src/test/resources/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/artifactsWithAPomAreTolerated.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/artifactsWithAPomAreTolerated.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersions.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersions.gradle
@@ -15,10 +15,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenSameBomIsImportedMultipleTimes.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenSameBomIsImportedMultipleTimes.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished.gradle
@@ -30,10 +30,11 @@ publishing {
 
 task managedVersionsAfterPublishPom {
 	dependsOn generatePomFileForMavenPublication
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomPropertyCanBeUsedToVersionADependency.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomPropertyCanBeUsedToVersionADependency.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.myConfiguration.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.myConfiguration.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomThatReferencesJavaHomeCanBeImported.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomThatReferencesJavaHomeCanBeImported.gradle
@@ -15,10 +15,11 @@ dependencyManagement {
 
 
 task managedVersions {
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomWithNoDependencyManagementCanBeImportedAndItsPropertiesUsed.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomWithNoDependencyManagementCanBeImportedAndItsPropertiesUsed.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task importedProperties {
+	def importedProperties = project.dependencyManagement.importedProperties
+	def output = new File("${buildDir}/imported-properties.txt")
 	doFirst {
-		def output = new File("${buildDir}/imported-properties.txt")
 		output.parentFile.mkdirs()
-		project.dependencyManagement.importedProperties.each { key, value ->
+		importedProperties.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeReferredToByNameWhenConfiguringConfigurationSpecificDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeReferredToByNameWhenConfiguringConfigurationSpecificDependencyManagement.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def managedVersions = dependencyManagement.implementation.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeUsedDirectlyWhenConfiguringConfigurationSpecificDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeUsedDirectlyWhenConfiguringConfigurationSpecificDependencyManagement.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def managedVersions = dependencyManagement.implementation.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementIsInheritedByExtendingConfigurations.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementIsInheritedByExtendingConfigurations.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.testRuntimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.testRuntimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementTakesPrecedenceOverGlobalDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementTakesPrecedenceOverGlobalDependencyManagement.gradle
@@ -23,9 +23,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/constraintsInTransitivePlatformDependenciesDoNotPreventExclusionsFromWorking.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/constraintsInTransitivePlatformDependenciesDoNotPreventExclusionsFromWorking.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+    def files = project.configurations.compileClasspath.incoming.files
+    def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesDeclaredInAPlatformAreNotAccidentallyExcluded.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesDeclaredInAPlatformAreNotAccidentallyExcluded.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesWithExtremelyLargePomsAreHandled.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesWithExtremelyLargePomsAreHandled.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementBeingOverridenByDependenciesCanBeDisabled.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementBeingOverridenByDependenciesCanBeDisabled.gradle
@@ -21,9 +21,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToASpecificConfiguration.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToASpecificConfiguration.gradle
@@ -25,18 +25,18 @@ dependencies {
 }
 
 task resolveManaged {
+	def files = project.configurations.managed.incoming.files
+	def output = new File("${buildDir}/resolved-managed.txt")
 	doFirst {
-		def files = project.configurations.managed.resolve()
-		def output = new File("${buildDir}/resolved-managed.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveUnmanaged {
+	def files = project.configurations.unmanaged.incoming.files
+	def output = new File("${buildDir}/resolved-unmanaged.txt")
 	doFirst {
-		def files = project.configurations.unmanaged.resolve()
-		def output = new File("${buildDir}/resolved-unmanaged.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToMultipleSpecificConfigurations.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToMultipleSpecificConfigurations.gradle
@@ -27,27 +27,27 @@ dependencies {
 }
 
 task resolveManaged1 {
+	def files = project.configurations.managed2.incoming.files
+	def output = new File("${buildDir}/resolved-managed1.txt")
 	doFirst {
-		def files = project.configurations.managed2.resolve()
-		def output = new File("${buildDir}/resolved-managed1.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveManaged2 {
+	def files = project.configurations.managed1.incoming.files
+	def output = new File("${buildDir}/resolved-managed2.txt")
 	doFirst {
-		def files = project.configurations.managed1.resolve()
-		def output = new File("${buildDir}/resolved-managed2.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveUnmanaged {
+	def files = project.configurations.unmanaged.incoming.files
+	def output = new File("${buildDir}/resolved-unmanaged.txt")
 	doFirst {
-		def files = project.configurations.unmanaged.resolve()
-		def output = new File("${buildDir}/resolved-unmanaged.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuild.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuild.gradle
@@ -21,9 +21,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuildUsingTheNewSyntax.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuildUsingTheNewSyntax.gradle
@@ -22,20 +22,21 @@ dependencyManagement {
 
 
 task managedVersions {
+	def managedVersions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}
 }
 
 task exclusions {
+	def output = new File("${buildDir}/exclusions.txt")
+	def exclusions = project.dependencyManagement.dependencyManagementContainer.getExclusions(null)
 	doFirst {
-		def output = new File("${buildDir}/exclusions.txt")
 		output.parentFile.mkdirs()
-		def exclusions = project.dependencyManagement.dependencyManagementContainer.getExclusions(null)
 		exclusions.exclusionsByDependency.each { key, value ->
 			output << "${key} -> "
 			output << value.collect { "${it.groupId}:${it.artifactId}" }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsAppliedToATransitiveDependencyDeclaredWithARange.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsAppliedToATransitiveDependencyDeclaredWithARange.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToADependencyUseLatestIntegration.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToADependencyUseLatestIntegration.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToAnInheritedDependencyUseLatestIntegration.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToAnInheritedDependencyUseLatestIntegration.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementWithExclusionsCanBeDeclaredInTheBuild.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementWithExclusionsCanBeDeclaredInTheBuild.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencySetCanBeUsedToProvideDependencyManagementForMultipleModulesWithTheSameGroupAndVersion.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencySetCanBeUsedToProvideDependencyManagementForMultipleModulesWithTheSameGroupAndVersion.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyVersionsCanBeDefinedUsingProperties.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyVersionsCanBeDefinedUsingProperties.gradle
@@ -22,10 +22,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyWithAnOtherwiseExcludedTransitiveDependencyOverridesTheExclude.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyWithAnOtherwiseExcludedTransitiveDependencyOverridesTheExclude.gradle
@@ -16,9 +16,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directExclusionDeclaredInABomIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directExclusionDeclaredInABomIsHonored.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dynamicVersionIsNotAddedToDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dynamicVersionIsNotAddedToDependencyManagement.gradle
@@ -12,11 +12,12 @@ dependencies {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
 		output.createNewFile()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionCanBeDeclaredOnAnEntryInADependencySet.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionCanBeDeclaredOnAnEntryInADependencySet.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionDeclaredOnTheDependencyThatHasTheExcludedDependencyIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionDeclaredOnTheDependencyThatHasTheExcludedDependencyIsHonored.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatAppliesTransitivelyIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatAppliesTransitivelyIsHonored.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatIsMalformedIsTolerated.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatIsMalformedIsTolerated.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedCorrectlyToDependenciesThatAreReferencedMultipleTimes.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedCorrectlyToDependenciesThatAreReferencedMultipleTimes.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedToDependenciesVersionedWithConstraints.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedToDependenciesVersionedWithConstraints.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreHandledCorrectlyForDependenciesThatAppearMultipleTimes.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreHandledCorrectlyForDependenciesThatAppearMultipleTimes.gradle
@@ -13,9 +13,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectDirectDependencies.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectDirectDependencies.gradle
@@ -16,18 +16,18 @@ dependencies {
 }
 
 task resolveCompile {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved-compile.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved-compile.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveTestCompile {
+	def files = project.configurations.testCompileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved-test-compile.txt")
 	doFirst {
-		def files = project.configurations.testCompileClasspath.resolve()
-		def output = new File("${buildDir}/resolved-test-compile.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectTransitiveDependencies.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectTransitiveDependencies.gradle
@@ -19,9 +19,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.testRuntimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.testRuntimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsFromAncestorsOfADependencyAreAppliedCorrectly.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsFromAncestorsOfADependencyAreAppliedCorrectly.gradle
@@ -13,9 +13,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsInImportedBomsForUnresolvableDependenciesAreApplied.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsInImportedBomsForUnresolvableDependenciesAreApplied.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/explicitDependencyPreventsTheDependencyFromBeingExcluded.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/explicitDependencyPreventsTheDependencyFromBeingExcluded.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanReferenceAProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanReferenceAProperty.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanUsePropertyMethodToReferenceAProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanUsePropertyMethodToReferenceAProperty.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomCanBeUsedToApplyDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomCanBeUsedToApplyDependencyManagement.gradle
@@ -17,9 +17,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomsVersionsCanBeOverridden.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomsVersionsCanBeOverridden.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/jbossJavaEEBomCanBeImportedAndUsedForDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/jbossJavaEEBomCanBeImportedAndUsedForDependencyManagement.gradle
@@ -17,9 +17,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedDependencyCanBeConfiguredUsingAGString.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedDependencyCanBeConfiguredUsingAGString.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsCanBeAccessedProgramatically.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsCanBeAccessedProgramatically.gradle
@@ -24,30 +24,25 @@ dependencyManagement {
 	}
 }
 
-def verifyManagedVersion(def versions, def id, def expected) {
-	def actual = versions[id]
-	if (actual != expected) {
-		throw new GradleException("Managed version for '${id}' was '${actual}' but '${expected}' was expected")
-	}
-}
-
-
 task verify {
+	def implementationManagedVersions = dependencyManagement.implementation.managedVersions
+	def implementationManagedVersionsOutput = new File("${buildDir}/implementation-managed-versions.txt")
+	def testRuntimeOnlyManagedVersions = dependencyManagement.testRuntimeOnly.managedVersions
+	def testRuntimeOnlyManagedVersionsOutput = new File("${buildDir}/testRuntimeOnly-managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
+	def managedVersionsOutput = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "org.springframework:spring-core", "4.0.6.RELEASE")
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "org.springframework:spring-core", "4.0.6.RELEASE")
-		verifyManagedVersion(dependencyManagement.managedVersions, "org.springframework:spring-core", "4.0.6.RELEASE")
-		
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "com.foo:bar", null)
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "com.foo:bar", "1.2.3")
-		verifyManagedVersion(dependencyManagement.managedVersions, "com.foo:bar", null)
-		
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "com.alpha:bravo", "1.0")
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "com.alpha:bravo", "1.0")
-		verifyManagedVersion(dependencyManagement.managedVersions, "com.alpha:bravo", "1.0")
-		
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "com.alpha:charlie", "1.0")
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "com.alpha:charlie", "1.0")
-		verifyManagedVersion(dependencyManagement.managedVersions, "com.alpha:charlie", "1.0")
+		implementationManagedVersionsOutput.parentFile.mkdirs()
+		implementationManagedVersions.each { key, value ->
+			implementationManagedVersionsOutput << "${key} -> ${value}\n"
+		}
+		testRuntimeOnlyManagedVersionsOutput.parentFile.mkdirs()
+		testRuntimeOnlyManagedVersions.each { key, value ->
+			testRuntimeOnlyManagedVersionsOutput << "${key} -> ${value}\n"
+		}
+		managedVersionsOutput.parentFile.mkdirs()
+		managedVersions.each { key, value ->
+			managedVersionsOutput << "${key} -> ${value}\n"
+		}
 	}
 }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsOfAConfigurationCanBeAccessed.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsOfAConfigurationCanBeAccessed.gradle
@@ -15,17 +15,15 @@ dependencyManagement {
 	}
 }
 
-def verifyManagedVersion(def versions, def id, def expected) {
-	def actual = versions[id]
-	if (actual != expected) {
-		throw new GradleException("Managed version for '${id}' was '${actual}' but '${expected}' was expected")
-	}
-}
-
-
 task verify {
+	def testImplementationManagedVersions = dependencyManagement.testImplementation.managedVersions
+	def managedVersionsForTestImplementationConfiguration = dependencyManagement.getManagedVersionsForConfiguration(configurations.testImplementation)
+	def testImplementationManagedVersionsOutput = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		verifyManagedVersion(dependencyManagement.testImplementation.managedVersions, "org.springframework:spring-core", "4.1.8.RELEASE")
-		verifyManagedVersion(dependencyManagement.getManagedVersionsForConfiguration(configurations.testImplementation), "org.springframework:spring-core", null)
+		testImplementationManagedVersionsOutput.parentFile.mkdirs()
+		testImplementationManagedVersions.each { key, value ->
+			testImplementationManagedVersionsOutput << "${key} -> ${value}\n"
+		}
+		assert managedVersionsForTestImplementationConfiguration.isEmpty()
 	}
 }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/platformConstrainingATransitiveDependencyDoesNotAccidentallyExcludeThatDependency.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/platformConstrainingATransitiveDependencyDoesNotAccidentallyExcludeThatDependency.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/pomExclusionsCanBeDisabled.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/pomExclusionsCanBeDisabled.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertiesImportedFromABomCanBeAccessed.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertiesImportedFromABomCanBeAccessed.gradle
@@ -22,18 +22,19 @@ dependencyManagement {
 	}
 }
 
-def verifyImportedProperty(def properties, def name, def expected) {
-	def actual = properties[name]
-	if (actual != expected) {
-		throw new GradleException("Property named '${name}' was '${actual}' but '${expected}' was expected")
-	}
-}
-
-
 task verify {
+	def importedProperties = dependencyManagement.importedProperties
+	def importedPropertiesOutput = new File("${buildDir}/imported-properties.txt")
+	def myConfigurationImportedProperties = dependencyManagement.myConfiguration.importedProperties
+	def myConfigurationImportedPropertiesOutput = new File("${buildDir}/myConfiguration-imported-properties.txt")
 	doFirst {
-		verifyImportedProperty(dependencyManagement.importedProperties, "hibernate.version", "4.3.5.Final")
-		verifyImportedProperty(dependencyManagement.myConfiguration.importedProperties, "spring.version", "4.1.4.RELEASE")
-		verifyImportedProperty(dependencyManagement.myConfiguration.importedProperties, "jruby.version", "1.7.12")
+		importedPropertiesOutput.parentFile.mkdirs()
+		importedProperties.each { key, value ->
+			importedPropertiesOutput << "${key} -> ${value}\n"
+		}
+		myConfigurationImportedPropertiesOutput.parentFile.mkdirs()
+		myConfigurationImportedProperties.each { key, value ->
+			myConfigurationImportedPropertiesOutput << "${key} -> ${value}\n"
+		}
 	}
 }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeConfiguredUsingAReferenceToAProjectProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeConfiguredUsingAReferenceToAProjectProperty.gradle
@@ -18,10 +18,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeOverriddenWhenItIsImported.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeOverriddenWhenItIsImported.gradle
@@ -17,10 +17,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyHasAnInvalidPom.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyHasAnInvalidPom.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnConstraintsFromPlatformDependencies.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnConstraintsFromPlatformDependencies.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnDependencyManagementFromItsAncestors.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnDependencyManagementFromItsAncestors.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/springCloudStarterParentBomCanBeImportedAndUsedForDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/springCloudStarterParentBomCanBeImportedAndUsedForDependencyManagement.gradle
@@ -18,10 +18,11 @@ dependencyManagement {
 
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependenciesWithACircularReferenceAreTolerated.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependenciesWithACircularReferenceAreTolerated.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependencyWithAnUnexcludedPathPreventsExclusion.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependencyWithAnUnexcludedPathPreventsExclusion.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveExclusionDeclaredInABomIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveExclusionDeclaredInABomIsHonored.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
@@ -19,9 +19,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/unresolvableDependenciesAreIgnoredWhenApplyingMavenStyleExclusions.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/unresolvableDependenciesAreIgnoredWhenApplyingMavenStyleExclusions.gradle
@@ -27,9 +27,9 @@ configurations {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/userProvidedResolutionStrategyRunsAfterInternalResolutionStrategy.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/userProvidedResolutionStrategyRunsAfterInternalResolutionStrategy.gradle
@@ -37,9 +37,9 @@ configurations.all {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionOnADirectDependencyProvidesDependencyManagementToExtendingConfigurations.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionOnADirectDependencyProvidesDependencyManagementToExtendingConfigurations.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.testRuntimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.testRuntimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDependencyManagementInAnImportedBom.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDependencyManagementInAnImportedBom.gradle
@@ -17,9 +17,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDirectDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDirectDependencyManagement.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/violationOfConfigurationCache.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/violationOfConfigurationCache.gradle
@@ -1,0 +1,9 @@
+plugins {
+	id "java"
+}
+
+task violate {
+	doFirst {
+		println project.name
+	}
+}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenDependencyIsSubstitutedNewCoordinatesAreUsedForDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenDependencyIsSubstitutedNewCoordinatesAreUsedForDependencyManagement.gradle
@@ -32,9 +32,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithAClassifierIsIgnored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithAClassifierIsIgnored.gradle
@@ -17,11 +17,12 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.implementation.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
 		output.createNewFile()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithNoVersionIsIgnored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithNoVersionIsIgnored.gradle
@@ -17,11 +17,12 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.implementation.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
 		output.createNewFile()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenOverridingABomPropertyAPropertyOnAnImportTakesPrecedenceOverAProjectProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenOverridingABomPropertyAPropertyOnAnImportTakesPrecedenceOverAProjectProperty.gradle
@@ -18,10 +18,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/wildcardExclusionDeclaredInABomIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/wildcardExclusionDeclaredInABomIsHonored.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/GVCIT/pluginIsCompatible.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/GVCIT/pluginIsCompatible.gradle
@@ -18,8 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def runtimeClasspathArtifacts = configurations.runtimeClasspath.incoming.files
 	doFirst {
-		def names = configurations.runtimeClasspath.resolve().collect { it.name }
+		def names = runtimeClasspathArtifacts.collect { it.name }
 		if (!names.containsAll("spring-boot-starter-1.4.2.RELEASE.jar", "spring-boot-1.4.2.RELEASE.jar",
 				"spring-boot-autoconfigure-1.4.2.RELEASE.jar",
 				"spring-boot-starter-logging-1.4.2.RELEASE.jar", "spring-core-4.3.4.RELEASE.jar",


### PR DESCRIPTION
StandardPomDependencyManagementConfigurer configures the POM and runs during the execution phase. In the process, it computes and resolves BOM references using Gradle model types, which violates the configuration cache.

As I understand it, resolved BOMs can be obtained during the configuration phase, so I moved the resolving step there under `project.afterEvaluate` callback.

I'm not entirely sure about the correctness of these changes, but all tests passed after enabling the configuration cache.