### PR TITLE
Do not apply PomDependencyManagementConfigurer when POM customization is disabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'maven-publish'
 
 	id 'io.spring.javaformat' version '0.0.39'
-	id 'io.spring.nohttp' version '0.0.10'
+	id 'io.spring.nohttp' version '0.0.11'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 

--- a/src/main/java/io/spring/gradle/dependencymanagement/DependencyManagementPlugin.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/DependencyManagementPlugin.java
@@ -41,15 +41,20 @@ public class DependencyManagementPlugin implements Plugin<Project> {
 		internalComponents.createDependencyManagementReportTask("dependencyManagement");
 		project.getConfigurations().all(internalComponents.getImplicitDependencyManagementCollector());
 		project.getConfigurations().all(internalComponents.getDependencyManagementApplier());
-		configurePomCustomization(project, dependencyManagementExtension);
+		configurePomCustomization(internalComponents, project, dependencyManagementExtension);
 	}
 
-	private void configurePomCustomization(Project project,
+	private void configurePomCustomization(InternalComponents internalComponents, Project project,
 			DependencyManagementExtension dependencyManagementExtension) {
-		PomDependencyManagementConfigurer pomConfigurer = dependencyManagementExtension.getPomConfigurer();
-		project.getPlugins()
-			.withType(MavenPublishPlugin.class,
-					(mavenPublishPlugin) -> configurePublishingExtension(project, pomConfigurer));
+		project.afterEvaluate((evaluatedProject) -> {
+			if (!internalComponents.getDependencyManagementSettings().getPomCustomizationSettings().isEnabled()) {
+				return;
+			}
+			PomDependencyManagementConfigurer pomConfigurer = dependencyManagementExtension.getPomConfigurer();
+			evaluatedProject.getPlugins()
+				.withType(MavenPublishPlugin.class,
+						(mavenPublishPlugin) -> configurePublishingExtension(evaluatedProject, pomConfigurer));
+		});
 	}
 
 	private void configurePublishingExtension(Project project, PomDependencyManagementConfigurer extension) {

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagement.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/DependencyManagement.java
@@ -22,12 +22,14 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import io.spring.gradle.dependencymanagement.internal.pom.Coordinates;
 import io.spring.gradle.dependencymanagement.internal.pom.Dependency;
 import io.spring.gradle.dependencymanagement.internal.pom.Pom;
 import io.spring.gradle.dependencymanagement.internal.pom.PomReference;
 import io.spring.gradle.dependencymanagement.internal.pom.PomResolver;
+import io.spring.gradle.dependencymanagement.internal.properties.MapPropertySource;
 import io.spring.gradle.dependencymanagement.internal.properties.ProjectPropertySource;
 import io.spring.gradle.dependencymanagement.internal.properties.PropertySource;
 import org.gradle.api.GradleException;
@@ -80,7 +82,11 @@ public class DependencyManagement {
 		this.importedBoms.add(new PomReference(coordinates, properties));
 	}
 
-	List<PomReference> getImportedBomReferences() {
+	/**
+	 * Returns the imported bom references.
+	 * @return the imported bom references
+	 */
+	public List<PomReference> getImportedBomReferences() {
 		return Collections.unmodifiableList(this.importedBoms);
 	}
 
@@ -125,6 +131,54 @@ public class DependencyManagement {
 		return managedDependencies;
 	}
 
+	/**
+	 * Returns the overridden dependencies.
+	 * @return the overridden dependencies
+	 */
+	public List<Dependency> getOverriddenDependencies() {
+		Map<String, Dependency> withoutPropertiesManagedDependencies = getManagedDependenciesById(
+				new MapPropertySource(Collections.emptyMap()));
+		Map<String, Dependency> withPropertiesManagedDependencies = getManagedDependenciesById(
+				new ProjectPropertySource(this.project));
+		List<Dependency> overrides = new ArrayList<>();
+		for (Map.Entry<String, Dependency> withPropertyEntry : withPropertiesManagedDependencies.entrySet()) {
+			Dependency withoutPropertyDependency = withoutPropertiesManagedDependencies.get(withPropertyEntry.getKey());
+			if (differentVersions(withoutPropertyDependency, withPropertyEntry.getValue())) {
+				overrides.add(withPropertyEntry.getValue());
+			}
+		}
+		return overrides;
+	}
+
+	private boolean differentVersions(Dependency dependency1, Dependency dependency2) {
+		if (dependency1 == null) {
+			return true;
+		}
+		String version1 = dependency1.getCoordinates().getVersion();
+		String version2 = dependency2.getCoordinates().getVersion();
+		return !Objects.equals(version1, version2);
+	}
+
+	private Map<String, Dependency> getManagedDependenciesById(PropertySource propertySource) {
+		Map<String, Dependency> managedDependencies = new HashMap<>();
+		for (Pom pom : getResolvedBoms(propertySource)) {
+			for (Dependency dependency : pom.getManagedDependencies()) {
+				managedDependencies.put(createId(dependency), dependency);
+			}
+		}
+		return managedDependencies;
+	}
+
+	private String createId(Dependency dependency) {
+		Coordinates coordinates = dependency.getCoordinates();
+		return String.format("%s:%s:%s:%s", coordinates.getGroupAndArtifactId(), dependency.getScope(),
+				dependency.getType(), dependency.getClassifier());
+	}
+
+	private List<Pom> getResolvedBoms(PropertySource propertySource) {
+		return this.pomResolver.resolvePoms(this.importedBoms, propertySource);
+	}
+
 	private String createKey(String group, String name) {
 		return group + ":" + name;
 	}
@@ -166,9 +220,7 @@ public class DependencyManagement {
 		}
 		Map<String, String> existingVersions = new LinkedHashMap<>(this.versions);
 		logger.debug("Preserving existing versions: {}", existingVersions);
-		List<Pom> resolvedBoms = this.pomResolver.resolvePoms(this.importedBoms,
-				new ProjectPropertySource(this.project));
-		for (Pom resolvedBom : resolvedBoms) {
+		for (Pom resolvedBom : getResolvedBoms(new ProjectPropertySource(this.project))) {
 			for (Dependency dependency : resolvedBom.getManagedDependencies()) {
 				resolve(resolvedBom, dependency);
 			}

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
@@ -18,21 +18,15 @@ package io.spring.gradle.dependencymanagement.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Supplier;
 
 import groovy.namespace.QName;
 import groovy.util.Node;
 import io.spring.gradle.dependencymanagement.internal.pom.Coordinates;
 import io.spring.gradle.dependencymanagement.internal.pom.Dependency;
-import io.spring.gradle.dependencymanagement.internal.pom.Pom;
 import io.spring.gradle.dependencymanagement.internal.pom.PomReference;
-import io.spring.gradle.dependencymanagement.internal.pom.PomResolver;
-import io.spring.gradle.dependencymanagement.internal.properties.ProjectPropertySource;
-import io.spring.gradle.dependencymanagement.internal.properties.PropertySource;
 import io.spring.gradle.dependencymanagement.maven.PomDependencyManagementConfigurer;
-import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
 
 /**
@@ -42,8 +36,6 @@ import org.gradle.api.XmlProvider;
  * @author Rupert Waldron
  */
 public class StandardPomDependencyManagementConfigurer implements PomDependencyManagementConfigurer {
-
-	private static final PropertySource EMPTY_PROPERTY_SOURCE = (name) -> null;
 
 	private static final String NODE_NAME_DEPENDENCY_MANAGEMENT = "dependencyManagement";
 
@@ -67,27 +59,26 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 
 	private static final String NODE_NAME_CLASSIFIER = "classifier";
 
-	private final DependencyManagement dependencyManagement;
+	private final List<Dependency> managedDependencies;
 
-	private final PomResolver pomResolver;
+	private final Supplier<List<Dependency>> overriddenDependenciesSupplier;
 
-	private final Project project;
+	private final List<PomReference> importedBomReferences;
 
 	/**
 	 * Creates a new {@code StandardPomDependencyManagementConfigurer} that will configure
 	 * the pom's dependency management to reflect the given {@code dependencyManagement}.
 	 * The given {@code settings} will control how the dependency management is applied to
 	 * the pom.
-	 * @param dependencyManagement the dependency management
-	 * @param pomResolver resolves imported boms during dependency management
-	 * configuration
-	 * @param project owner of the pom that is being configured
+	 * @param managedDependencies the managed dependencies
+	 * @param overriddenDependenciesSupplier the overridden dependencies supplier
+	 * @param importedBomReferences the bom references
 	 */
-	public StandardPomDependencyManagementConfigurer(DependencyManagement dependencyManagement, PomResolver pomResolver,
-			Project project) {
-		this.dependencyManagement = dependencyManagement;
-		this.pomResolver = pomResolver;
-		this.project = project;
+	public StandardPomDependencyManagementConfigurer(List<Dependency> managedDependencies,
+			Supplier<List<Dependency>> overriddenDependenciesSupplier, List<PomReference> importedBomReferences) {
+		this.managedDependencies = managedDependencies;
+		this.overriddenDependenciesSupplier = overriddenDependenciesSupplier;
+		this.importedBomReferences = importedBomReferences;
 	}
 
 	@Override
@@ -127,52 +118,14 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 	}
 
 	private void configureBomImports(Node dependencies) {
-		List<PomReference> bomReferences = this.dependencyManagement.getImportedBomReferences();
-		Map<String, Dependency> withoutPropertiesManagedDependencies = getManagedDependenciesById(bomReferences,
-				EMPTY_PROPERTY_SOURCE);
-		Map<String, Dependency> withPropertiesManagedDependencies = getManagedDependenciesById(bomReferences,
-				new ProjectPropertySource(this.project));
-		List<Dependency> overrides = new ArrayList<>();
-		for (Map.Entry<String, Dependency> withPropertyEntry : withPropertiesManagedDependencies.entrySet()) {
-			Dependency withoutPropertyDependency = withoutPropertiesManagedDependencies.get(withPropertyEntry.getKey());
-			if (differentVersions(withoutPropertyDependency, withPropertyEntry.getValue())) {
-				overrides.add(withPropertyEntry.getValue());
-			}
-		}
-		for (Dependency override : overrides) {
+		for (Dependency override : this.overriddenDependenciesSupplier.get()) {
 			appendDependencyNode(dependencies, override.getCoordinates(), override.getScope(), override.getType());
 		}
-		List<PomReference> importOrderBomReferences = new ArrayList<>(bomReferences);
+		List<PomReference> importOrderBomReferences = new ArrayList<>(this.importedBomReferences);
 		Collections.reverse(importOrderBomReferences);
 		for (PomReference bomReference : importOrderBomReferences) {
 			addImport(dependencies, bomReference);
 		}
-	}
-
-	private Map<String, Dependency> getManagedDependenciesById(List<PomReference> bomReferences,
-			PropertySource propertySource) {
-		Map<String, Dependency> managedDependencies = new HashMap<>();
-		for (Pom pom : this.pomResolver.resolvePoms(bomReferences, propertySource)) {
-			for (Dependency dependency : pom.getManagedDependencies()) {
-				managedDependencies.put(createId(dependency), dependency);
-			}
-		}
-		return managedDependencies;
-	}
-
-	private String createId(Dependency dependency) {
-		Coordinates coordinates = dependency.getCoordinates();
-		return String.format("%s:%s:%s:%s", coordinates.getGroupAndArtifactId(), dependency.getScope(),
-				dependency.getType(), dependency.getClassifier());
-	}
-
-	private boolean differentVersions(Dependency dependency1, Dependency dependency2) {
-		if (dependency1 == null) {
-			return true;
-		}
-		String version1 = dependency1.getCoordinates().getVersion();
-		String version2 = dependency2.getCoordinates().getVersion();
-		return !version1.equals(version2);
 	}
 
 	private void addImport(Node dependencies, PomReference importedBom) {
@@ -194,7 +147,7 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 	}
 
 	private void configureManagedDependencies(Node managedDependencies, Node dependencies) {
-		for (Dependency managedDependency : this.dependencyManagement.getManagedDependencies()) {
+		for (Dependency managedDependency : this.managedDependencies) {
 			addManagedDependency(managedDependencies, managedDependency, null);
 			if (dependencies != null) {
 				for (String classifier : findClassifiers(dependencies, managedDependency)) {

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurer.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import groovy.namespace.QName;
 import groovy.util.Node;
-import io.spring.gradle.dependencymanagement.internal.DependencyManagementSettings.PomCustomizationSettings;
 import io.spring.gradle.dependencymanagement.internal.pom.Coordinates;
 import io.spring.gradle.dependencymanagement.internal.pom.Dependency;
 import io.spring.gradle.dependencymanagement.internal.pom.Pom;
@@ -70,8 +69,6 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 
 	private final DependencyManagement dependencyManagement;
 
-	private final PomCustomizationSettings settings;
-
 	private final PomResolver pomResolver;
 
 	private final Project project;
@@ -82,15 +79,13 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 	 * The given {@code settings} will control how the dependency management is applied to
 	 * the pom.
 	 * @param dependencyManagement the dependency management
-	 * @param settings the customization settings
 	 * @param pomResolver resolves imported boms during dependency management
 	 * configuration
 	 * @param project owner of the pom that is being configured
 	 */
-	public StandardPomDependencyManagementConfigurer(DependencyManagement dependencyManagement,
-			PomCustomizationSettings settings, PomResolver pomResolver, Project project) {
+	public StandardPomDependencyManagementConfigurer(DependencyManagement dependencyManagement, PomResolver pomResolver,
+			Project project) {
 		this.dependencyManagement = dependencyManagement;
-		this.settings = settings;
 		this.pomResolver = pomResolver;
 		this.project = project;
 	}
@@ -102,12 +97,6 @@ public class StandardPomDependencyManagementConfigurer implements PomDependencyM
 
 	@Override
 	public void configurePom(Node pom) {
-		if (this.settings.isEnabled()) {
-			doConfigurePom(pom);
-		}
-	}
-
-	private void doConfigurePom(Node pom) {
 		Node dependencyManagementNode = findChild(pom, NODE_NAME_DEPENDENCY_MANAGEMENT);
 		if (dependencyManagementNode == null) {
 			dependencyManagementNode = pom.appendNode(NODE_NAME_DEPENDENCY_MANAGEMENT);

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/bridge/InternalComponents.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/bridge/InternalComponents.java
@@ -41,6 +41,8 @@ public class InternalComponents {
 
 	private final DependencyManagementExtension dependencyManagementExtension;
 
+	private final DependencyManagementSettings dependencyManagementSettings;
+
 	private final Action<Configuration> implicitDependencyManagementCollector;
 
 	private final Action<Configuration> dependencyManagementApplier;
@@ -58,13 +60,13 @@ public class InternalComponents {
 				project);
 		MavenPomResolver pomResolver = new MavenPomResolver(project, configurationContainer);
 		this.dependencyManagementContainer = new DependencyManagementContainer(project, pomResolver);
-		DependencyManagementSettings dependencyManagementSettings = new DependencyManagementSettings();
+		this.dependencyManagementSettings = new DependencyManagementSettings();
 		this.dependencyManagementExtension = new StandardDependencyManagementExtension(
-				this.dependencyManagementContainer, configurationContainer, project, dependencyManagementSettings);
+				this.dependencyManagementContainer, configurationContainer, project, this.dependencyManagementSettings);
 		this.implicitDependencyManagementCollector = new ImplicitDependencyManagementCollector(
-				this.dependencyManagementContainer, dependencyManagementSettings);
+				this.dependencyManagementContainer, this.dependencyManagementSettings);
 		this.dependencyManagementApplier = new DependencyManagementApplier(project, this.dependencyManagementContainer,
-				configurationContainer, dependencyManagementSettings, pomResolver);
+				configurationContainer, this.dependencyManagementSettings, pomResolver);
 	}
 
 	/**
@@ -73,6 +75,14 @@ public class InternalComponents {
 	 */
 	public DependencyManagementExtension getDependencyManagementExtension() {
 		return this.dependencyManagementExtension;
+	}
+
+	/**
+	 * Returns the {@link DependencyManagementSettings}.
+	 * @return the settings
+	 */
+	public DependencyManagementSettings getDependencyManagementSettings() {
+		return this.dependencyManagementSettings;
 	}
 
 	/**

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardDependencyManagementExtension.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardDependencyManagementExtension.java
@@ -28,12 +28,12 @@ import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension;
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementHandler;
 import io.spring.gradle.dependencymanagement.dsl.GeneratedPomCustomizationHandler;
 import io.spring.gradle.dependencymanagement.dsl.ImportsHandler;
+import io.spring.gradle.dependencymanagement.internal.DependencyManagement;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementConfigurationContainer;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementContainer;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementSettings;
 import io.spring.gradle.dependencymanagement.internal.DependencyManagementSettings.PomCustomizationSettings;
 import io.spring.gradle.dependencymanagement.internal.StandardPomDependencyManagementConfigurer;
-import io.spring.gradle.dependencymanagement.internal.maven.MavenPomResolver;
 import org.codehaus.groovy.runtime.ReflectionMethodInvoker;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -139,9 +139,9 @@ public class StandardDependencyManagementExtension extends GroovyObjectSupport
 
 	@Override
 	public StandardPomDependencyManagementConfigurer getPomConfigurer() {
-		return new StandardPomDependencyManagementConfigurer(
-				this.dependencyManagementContainer.getGlobalDependencyManagement(),
-				new MavenPomResolver(this.project, this.configurationContainer), this.project);
+		DependencyManagement dependencyManagement = this.dependencyManagementContainer.getGlobalDependencyManagement();
+		return new StandardPomDependencyManagementConfigurer(dependencyManagement.getManagedDependencies(),
+				dependencyManagement::getOverriddenDependencies, dependencyManagement.getImportedBomReferences());
 	}
 
 	/**
@@ -231,6 +231,14 @@ public class StandardDependencyManagementExtension extends GroovyObjectSupport
 	 */
 	public PomCustomizationSettings getPomCustomizationSettings() {
 		return this.dependencyManagementSettings.getPomCustomizationSettings();
+	}
+
+	/**
+	 * Returns the {@link DependencyManagementContainer}.
+	 * @return the container
+	 */
+	public DependencyManagementContainer getDependencyManagementContainer() {
+		return this.dependencyManagementContainer;
 	}
 
 }

--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardDependencyManagementExtension.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/StandardDependencyManagementExtension.java
@@ -141,7 +141,6 @@ public class StandardDependencyManagementExtension extends GroovyObjectSupport
 	public StandardPomDependencyManagementConfigurer getPomConfigurer() {
 		return new StandardPomDependencyManagementConfigurer(
 				this.dependencyManagementContainer.getGlobalDependencyManagement(),
-				this.dependencyManagementSettings.getPomCustomizationSettings(),
 				new MavenPomResolver(this.project, this.configurationContainer), this.project);
 	}
 

--- a/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/DependencyManagementPluginIntegrationTests.java
@@ -182,11 +182,26 @@ class DependencyManagementPluginIntegrationTests {
 	@Test
 	void managedVersionsCanBeAccessedProgramatically() {
 		this.gradleBuild.runner().withArguments("verify").build();
+		assertThat(readLines("implementation-managed-versions.txt"))
+			.contains("org.springframework:spring-core -> 4.0.6.RELEASE", "com.alpha:bravo -> 1.0",
+					"com.alpha:charlie -> 1.0")
+			.doesNotContain("com.foo:bar");
+		assertThat(readLines("testRuntimeOnly-managed-versions.txt"))
+			.contains("org.springframework:spring-core -> 4.0.6.RELEASE", "com.foo:bar -> 1.2.3",
+					"com.alpha:bravo -> 1.0", "com.alpha:charlie -> 1.0")
+			.doesNotContain("com.foo:bar");
+		assertThat(readLines("managed-versions.txt"))
+			.contains("org.springframework:spring-core -> 4.0.6.RELEASE", "com.alpha:bravo -> 1.0",
+					"com.alpha:charlie -> 1.0")
+			.doesNotContain("com.foo:bar");
 	}
 
 	@Test
 	void propertiesImportedFromABomCanBeAccessed() {
 		this.gradleBuild.runner().withArguments("verify").build();
+		assertThat(readLines("imported-properties.txt")).contains("hibernate.version -> 4.3.5.Final");
+		assertThat(readLines("myConfiguration-imported-properties.txt")).contains("spring.version -> 4.1.4.RELEASE",
+				"jruby.version -> 1.7.12");
 	}
 
 	@Test
@@ -347,6 +362,7 @@ class DependencyManagementPluginIntegrationTests {
 	@Test
 	void managedVersionsOfAConfigurationCanBeAccessed() {
 		this.gradleBuild.runner().withArguments("verify").build();
+		assertThat(readLines("managed-versions.txt")).contains("org.springframework:spring-core -> 4.1.8.RELEASE");
 	}
 
 	@Test

--- a/src/test/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurerTests.java
+++ b/src/test/java/io/spring/gradle/dependencymanagement/internal/StandardPomDependencyManagementConfigurerTests.java
@@ -24,7 +24,6 @@ import groovy.util.Node;
 import groovy.xml.XmlParser;
 import groovy.xml.XmlUtil;
 import io.spring.gradle.dependencymanagement.NodeAssert;
-import io.spring.gradle.dependencymanagement.internal.DependencyManagementSettings.PomCustomizationSettings;
 import io.spring.gradle.dependencymanagement.internal.maven.MavenPomResolver;
 import io.spring.gradle.dependencymanagement.internal.pom.Coordinates;
 import io.spring.gradle.dependencymanagement.internal.pom.PomResolver;
@@ -103,17 +102,6 @@ class StandardPomDependencyManagementConfigurerTests {
 		assertThat(pom).textAtPath("//project/dependencyManagement/dependencies/dependency[2]/scope")
 			.isEqualTo("import");
 		assertThat(pom).textAtPath("//project/dependencyManagement/dependencies/dependency[2]/type").isEqualTo("pom");
-	}
-
-	@Test
-	void customizationOfPublishedPomsCanBeDisabled() throws Exception {
-		this.dependencyManagement.importBom(null,
-				new Coordinates("io.spring.platform", "platform-bom", "1.0.3.RELEASE"),
-				new MapPropertySource(Collections.emptyMap()));
-		PomCustomizationSettings settings = new PomCustomizationSettings();
-		settings.setEnabled(false);
-		NodeAssert pom = configuredPom(settings);
-		assertThat(pom).nodesAtPath("//project/dependencyManagement/dependencies/dependency").isEmpty();
 	}
 
 	@Test
@@ -263,21 +251,13 @@ class StandardPomDependencyManagementConfigurerTests {
 	}
 
 	private NodeAssert configuredPom() throws Exception {
-		return configuredPom(new PomCustomizationSettings());
+		return configuredPom(PROJECT_TAG + "</project>");
 	}
 
 	private NodeAssert configuredPom(String existingPom) throws Exception {
-		return configuredPom(existingPom, new PomCustomizationSettings());
-	}
-
-	private NodeAssert configuredPom(PomCustomizationSettings settings) throws Exception {
-		return configuredPom(PROJECT_TAG + "</project>", settings);
-	}
-
-	private NodeAssert configuredPom(String existingPom, PomCustomizationSettings settings) throws Exception {
 		Node pom = new XmlParser().parseText(existingPom);
 		new StandardPomDependencyManagementConfigurer(this.dependencyManagement.getGlobalDependencyManagement(),
-				settings, this.pomResolver, this.project)
+				this.pomResolver, this.project)
 			.configurePom(pom);
 		return new NodeAssert(XmlUtil.serialize(pom));
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/artifactsWithAPomAreTolerated.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/artifactsWithAPomAreTolerated.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersions.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersions.gradle
@@ -15,10 +15,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenSameBomIsImportedMultipleTimes.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenSameBomIsImportedMultipleTimes.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomImportOrderIsReflectedInManagedVersionsWhenThePomIsPublished.gradle
@@ -30,10 +30,11 @@ publishing {
 
 task managedVersionsAfterPublishPom {
 	dependsOn generatePomFileForMavenPublication
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomPropertyCanBeUsedToVersionADependency.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomPropertyCanBeUsedToVersionADependency.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.myConfiguration.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.myConfiguration.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomThatReferencesJavaHomeCanBeImported.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomThatReferencesJavaHomeCanBeImported.gradle
@@ -15,10 +15,11 @@ dependencyManagement {
 
 
 task managedVersions {
+	def versions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		versions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomWithNoDependencyManagementCanBeImportedAndItsPropertiesUsed.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/bomWithNoDependencyManagementCanBeImportedAndItsPropertiesUsed.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task importedProperties {
+	def importedProperties = project.dependencyManagement.importedProperties
+	def output = new File("${buildDir}/imported-properties.txt")
 	doFirst {
-		def output = new File("${buildDir}/imported-properties.txt")
 		output.parentFile.mkdirs()
-		project.dependencyManagement.importedProperties.each { key, value ->
+		importedProperties.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeReferredToByNameWhenConfiguringConfigurationSpecificDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeReferredToByNameWhenConfiguringConfigurationSpecificDependencyManagement.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def managedVersions = dependencyManagement.implementation.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeUsedDirectlyWhenConfiguringConfigurationSpecificDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationCanBeUsedDirectlyWhenConfiguringConfigurationSpecificDependencyManagement.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def managedVersions = dependencyManagement.implementation.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementIsInheritedByExtendingConfigurations.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementIsInheritedByExtendingConfigurations.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.testRuntimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.testRuntimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementTakesPrecedenceOverGlobalDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/configurationSpecificDependencyManagementTakesPrecedenceOverGlobalDependencyManagement.gradle
@@ -23,9 +23,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/constraintsInTransitivePlatformDependenciesDoNotPreventExclusionsFromWorking.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/constraintsInTransitivePlatformDependenciesDoNotPreventExclusionsFromWorking.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+    def files = project.configurations.compileClasspath.incoming.files
+    def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesDeclaredInAPlatformAreNotAccidentallyExcluded.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesDeclaredInAPlatformAreNotAccidentallyExcluded.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesWithExtremelyLargePomsAreHandled.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependenciesWithExtremelyLargePomsAreHandled.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementBeingOverridenByDependenciesCanBeDisabled.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementBeingOverridenByDependenciesCanBeDisabled.gradle
@@ -21,9 +21,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToASpecificConfiguration.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToASpecificConfiguration.gradle
@@ -25,18 +25,18 @@ dependencies {
 }
 
 task resolveManaged {
+	def files = project.configurations.managed.incoming.files
+	def output = new File("${buildDir}/resolved-managed.txt")
 	doFirst {
-		def files = project.configurations.managed.resolve()
-		def output = new File("${buildDir}/resolved-managed.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveUnmanaged {
+	def files = project.configurations.unmanaged.incoming.files
+	def output = new File("${buildDir}/resolved-unmanaged.txt")
 	doFirst {
-		def files = project.configurations.unmanaged.resolve()
-		def output = new File("${buildDir}/resolved-unmanaged.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToMultipleSpecificConfigurations.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeAppliedToMultipleSpecificConfigurations.gradle
@@ -27,27 +27,27 @@ dependencies {
 }
 
 task resolveManaged1 {
+	def files = project.configurations.managed2.incoming.files
+	def output = new File("${buildDir}/resolved-managed1.txt")
 	doFirst {
-		def files = project.configurations.managed2.resolve()
-		def output = new File("${buildDir}/resolved-managed1.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveManaged2 {
+	def files = project.configurations.managed1.incoming.files
+	def output = new File("${buildDir}/resolved-managed2.txt")
 	doFirst {
-		def files = project.configurations.managed1.resolve()
-		def output = new File("${buildDir}/resolved-managed2.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveUnmanaged {
+	def files = project.configurations.unmanaged.incoming.files
+	def output = new File("${buildDir}/resolved-unmanaged.txt")
 	doFirst {
-		def files = project.configurations.unmanaged.resolve()
-		def output = new File("${buildDir}/resolved-unmanaged.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuild.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuild.gradle
@@ -21,9 +21,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuildUsingTheNewSyntax.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementCanBeDeclaredInTheBuildUsingTheNewSyntax.gradle
@@ -22,20 +22,21 @@ dependencyManagement {
 
 
 task managedVersions {
+	def managedVersions = dependencyManagement.managedVersions
+	def output = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}
 }
 
 task exclusions {
+	def output = new File("${buildDir}/exclusions.txt")
+	def exclusions = project.dependencyManagement.dependencyManagementContainer.getExclusions(null)
 	doFirst {
-		def output = new File("${buildDir}/exclusions.txt")
 		output.parentFile.mkdirs()
-		def exclusions = project.dependencyManagement.dependencyManagementContainer.getExclusions(null)
 		exclusions.exclusionsByDependency.each { key, value ->
 			output << "${key} -> "
 			output << value.collect { "${it.groupId}:${it.artifactId}" }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsAppliedToATransitiveDependencyDeclaredWithARange.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsAppliedToATransitiveDependencyDeclaredWithARange.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToADependencyUseLatestIntegration.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToADependencyUseLatestIntegration.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToAnInheritedDependencyUseLatestIntegration.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementIsNotAppliedToAnInheritedDependencyUseLatestIntegration.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementWithExclusionsCanBeDeclaredInTheBuild.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyManagementWithExclusionsCanBeDeclaredInTheBuild.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencySetCanBeUsedToProvideDependencyManagementForMultipleModulesWithTheSameGroupAndVersion.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencySetCanBeUsedToProvideDependencyManagementForMultipleModulesWithTheSameGroupAndVersion.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyVersionsCanBeDefinedUsingProperties.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyVersionsCanBeDefinedUsingProperties.gradle
@@ -22,10 +22,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyWithAnOtherwiseExcludedTransitiveDependencyOverridesTheExclude.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dependencyWithAnOtherwiseExcludedTransitiveDependencyOverridesTheExclude.gradle
@@ -16,9 +16,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directExclusionDeclaredInABomIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directExclusionDeclaredInABomIsHonored.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/directProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dynamicVersionIsNotAddedToDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/dynamicVersionIsNotAddedToDependencyManagement.gradle
@@ -12,11 +12,12 @@ dependencies {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
 		output.createNewFile()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionCanBeDeclaredOnAnEntryInADependencySet.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionCanBeDeclaredOnAnEntryInADependencySet.gradle
@@ -22,9 +22,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionDeclaredOnTheDependencyThatHasTheExcludedDependencyIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionDeclaredOnTheDependencyThatHasTheExcludedDependencyIsHonored.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatAppliesTransitivelyIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatAppliesTransitivelyIsHonored.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatIsMalformedIsTolerated.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionThatIsMalformedIsTolerated.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedCorrectlyToDependenciesThatAreReferencedMultipleTimes.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedCorrectlyToDependenciesThatAreReferencedMultipleTimes.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedToDependenciesVersionedWithConstraints.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreAppliedToDependenciesVersionedWithConstraints.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreHandledCorrectlyForDependenciesThatAppearMultipleTimes.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreHandledCorrectlyForDependenciesThatAppearMultipleTimes.gradle
@@ -13,9 +13,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectDirectDependencies.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectDirectDependencies.gradle
@@ -16,18 +16,18 @@ dependencies {
 }
 
 task resolveCompile {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved-compile.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved-compile.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}
 }
 
 task resolveTestCompile {
+	def files = project.configurations.testCompileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved-test-compile.txt")
 	doFirst {
-		def files = project.configurations.testCompileClasspath.resolve()
-		def output = new File("${buildDir}/resolved-test-compile.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectTransitiveDependencies.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsAreNotInheritedAndDoNotAffectTransitiveDependencies.gradle
@@ -19,9 +19,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.testRuntimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.testRuntimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsFromAncestorsOfADependencyAreAppliedCorrectly.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsFromAncestorsOfADependencyAreAppliedCorrectly.gradle
@@ -13,9 +13,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsInImportedBomsForUnresolvableDependenciesAreApplied.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/exclusionsInImportedBomsForUnresolvableDependenciesAreApplied.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/explicitDependencyPreventsTheDependencyFromBeingExcluded.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/explicitDependencyPreventsTheDependencyFromBeingExcluded.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanReferenceAProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanReferenceAProperty.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanUsePropertyMethodToReferenceAProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importOfABomCanUsePropertyMethodToReferenceAProperty.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomCanBeUsedToApplyDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomCanBeUsedToApplyDependencyManagement.gradle
@@ -17,9 +17,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomsVersionsCanBeOverridden.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/importedBomsVersionsCanBeOverridden.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/jbossJavaEEBomCanBeImportedAndUsedForDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/jbossJavaEEBomCanBeImportedAndUsedForDependencyManagement.gradle
@@ -17,9 +17,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedDependencyCanBeConfiguredUsingAGString.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedDependencyCanBeConfiguredUsingAGString.gradle
@@ -16,10 +16,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsCanBeAccessedProgramatically.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsCanBeAccessedProgramatically.gradle
@@ -24,30 +24,25 @@ dependencyManagement {
 	}
 }
 
-def verifyManagedVersion(def versions, def id, def expected) {
-	def actual = versions[id]
-	if (actual != expected) {
-		throw new GradleException("Managed version for '${id}' was '${actual}' but '${expected}' was expected")
-	}
-}
-
-
 task verify {
+	def implementationManagedVersions = dependencyManagement.implementation.managedVersions
+	def implementationManagedVersionsOutput = new File("${buildDir}/implementation-managed-versions.txt")
+	def testRuntimeOnlyManagedVersions = dependencyManagement.testRuntimeOnly.managedVersions
+	def testRuntimeOnlyManagedVersionsOutput = new File("${buildDir}/testRuntimeOnly-managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
+	def managedVersionsOutput = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "org.springframework:spring-core", "4.0.6.RELEASE")
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "org.springframework:spring-core", "4.0.6.RELEASE")
-		verifyManagedVersion(dependencyManagement.managedVersions, "org.springframework:spring-core", "4.0.6.RELEASE")
-		
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "com.foo:bar", null)
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "com.foo:bar", "1.2.3")
-		verifyManagedVersion(dependencyManagement.managedVersions, "com.foo:bar", null)
-		
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "com.alpha:bravo", "1.0")
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "com.alpha:bravo", "1.0")
-		verifyManagedVersion(dependencyManagement.managedVersions, "com.alpha:bravo", "1.0")
-		
-		verifyManagedVersion(dependencyManagement.implementation.managedVersions, "com.alpha:charlie", "1.0")
-		verifyManagedVersion(dependencyManagement.testRuntimeOnly.managedVersions, "com.alpha:charlie", "1.0")
-		verifyManagedVersion(dependencyManagement.managedVersions, "com.alpha:charlie", "1.0")
+		implementationManagedVersionsOutput.parentFile.mkdirs()
+		implementationManagedVersions.each { key, value ->
+			implementationManagedVersionsOutput << "${key} -> ${value}\n"
+		}
+		testRuntimeOnlyManagedVersionsOutput.parentFile.mkdirs()
+		testRuntimeOnlyManagedVersions.each { key, value ->
+			testRuntimeOnlyManagedVersionsOutput << "${key} -> ${value}\n"
+		}
+		managedVersionsOutput.parentFile.mkdirs()
+		managedVersions.each { key, value ->
+			managedVersionsOutput << "${key} -> ${value}\n"
+		}
 	}
 }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsOfAConfigurationCanBeAccessed.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/managedVersionsOfAConfigurationCanBeAccessed.gradle
@@ -15,17 +15,15 @@ dependencyManagement {
 	}
 }
 
-def verifyManagedVersion(def versions, def id, def expected) {
-	def actual = versions[id]
-	if (actual != expected) {
-		throw new GradleException("Managed version for '${id}' was '${actual}' but '${expected}' was expected")
-	}
-}
-
-
 task verify {
+	def testImplementationManagedVersions = dependencyManagement.testImplementation.managedVersions
+	def managedVersionsForTestImplementationConfiguration = dependencyManagement.getManagedVersionsForConfiguration(configurations.testImplementation)
+	def testImplementationManagedVersionsOutput = new File("${buildDir}/managed-versions.txt")
 	doFirst {
-		verifyManagedVersion(dependencyManagement.testImplementation.managedVersions, "org.springframework:spring-core", "4.1.8.RELEASE")
-		verifyManagedVersion(dependencyManagement.getManagedVersionsForConfiguration(configurations.testImplementation), "org.springframework:spring-core", null)
+		testImplementationManagedVersionsOutput.parentFile.mkdirs()
+		testImplementationManagedVersions.each { key, value ->
+			testImplementationManagedVersionsOutput << "${key} -> ${value}\n"
+		}
+		assert managedVersionsForTestImplementationConfiguration.isEmpty()
 	}
 }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/platformConstrainingATransitiveDependencyDoesNotAccidentallyExcludeThatDependency.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/platformConstrainingATransitiveDependencyDoesNotAccidentallyExcludeThatDependency.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/pomExclusionsCanBeDisabled.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/pomExclusionsCanBeDisabled.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertiesImportedFromABomCanBeAccessed.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertiesImportedFromABomCanBeAccessed.gradle
@@ -22,18 +22,19 @@ dependencyManagement {
 	}
 }
 
-def verifyImportedProperty(def properties, def name, def expected) {
-	def actual = properties[name]
-	if (actual != expected) {
-		throw new GradleException("Property named '${name}' was '${actual}' but '${expected}' was expected")
-	}
-}
-
-
 task verify {
+	def importedProperties = dependencyManagement.importedProperties
+	def importedPropertiesOutput = new File("${buildDir}/imported-properties.txt")
+	def myConfigurationImportedProperties = dependencyManagement.myConfiguration.importedProperties
+	def myConfigurationImportedPropertiesOutput = new File("${buildDir}/myConfiguration-imported-properties.txt")
 	doFirst {
-		verifyImportedProperty(dependencyManagement.importedProperties, "hibernate.version", "4.3.5.Final")
-		verifyImportedProperty(dependencyManagement.myConfiguration.importedProperties, "spring.version", "4.1.4.RELEASE")
-		verifyImportedProperty(dependencyManagement.myConfiguration.importedProperties, "jruby.version", "1.7.12")
+		importedPropertiesOutput.parentFile.mkdirs()
+		importedProperties.each { key, value ->
+			importedPropertiesOutput << "${key} -> ${value}\n"
+		}
+		myConfigurationImportedPropertiesOutput.parentFile.mkdirs()
+		myConfigurationImportedProperties.each { key, value ->
+			myConfigurationImportedPropertiesOutput << "${key} -> ${value}\n"
+		}
 	}
 }

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeConfiguredUsingAReferenceToAProjectProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeConfiguredUsingAReferenceToAProjectProperty.gradle
@@ -18,10 +18,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeOverriddenWhenItIsImported.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/propertyInABomCanBeOverriddenWhenItIsImported.gradle
@@ -17,10 +17,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyHasAnInvalidPom.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyHasAnInvalidPom.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnConstraintsFromPlatformDependencies.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnConstraintsFromPlatformDependencies.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnDependencyManagementFromItsAncestors.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/resolutionSucceedsWhenDependencyReliesOnDependencyManagementFromItsAncestors.gradle
@@ -15,9 +15,9 @@ dependencies {
 }
 
 tasks.register("resolve") {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/springCloudStarterParentBomCanBeImportedAndUsedForDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/springCloudStarterParentBomCanBeImportedAndUsedForDependencyManagement.gradle
@@ -18,10 +18,11 @@ dependencyManagement {
 
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependenciesWithACircularReferenceAreTolerated.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependenciesWithACircularReferenceAreTolerated.gradle
@@ -12,9 +12,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependencyWithAnUnexcludedPathPreventsExclusion.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveDependencyWithAnUnexcludedPathPreventsExclusion.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveExclusionDeclaredInABomIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveExclusionDeclaredInABomIsHonored.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/transitiveProjectDependenciesTakePrecedenceOverDependencyManagement.gradle
@@ -19,9 +19,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.runtimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.runtimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/unresolvableDependenciesAreIgnoredWhenApplyingMavenStyleExclusions.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/unresolvableDependenciesAreIgnoredWhenApplyingMavenStyleExclusions.gradle
@@ -27,9 +27,9 @@ configurations {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/userProvidedResolutionStrategyRunsAfterInternalResolutionStrategy.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/userProvidedResolutionStrategyRunsAfterInternalResolutionStrategy.gradle
@@ -37,9 +37,9 @@ configurations.all {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionOnADirectDependencyProvidesDependencyManagementToExtendingConfigurations.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionOnADirectDependencyProvidesDependencyManagementToExtendingConfigurations.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.testRuntimeClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.testRuntimeClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDependencyManagementInAnImportedBom.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDependencyManagementInAnImportedBom.gradle
@@ -17,9 +17,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDirectDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/versionsOfDirectDependenciesTakePrecedenceOverDirectDependencyManagement.gradle
@@ -18,9 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenDependencyIsSubstitutedNewCoordinatesAreUsedForDependencyManagement.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenDependencyIsSubstitutedNewCoordinatesAreUsedForDependencyManagement.gradle
@@ -32,9 +32,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithAClassifierIsIgnored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithAClassifierIsIgnored.gradle
@@ -17,11 +17,12 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.implementation.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
 		output.createNewFile()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithNoVersionIsIgnored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenImportingABomDependencyManagementWithNoVersionIsIgnored.gradle
@@ -17,11 +17,12 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.implementation.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
 		output.createNewFile()
-		dependencyManagement.implementation.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenOverridingABomPropertyAPropertyOnAnImportTakesPrecedenceOverAProjectProperty.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/whenOverridingABomPropertyAPropertyOnAnImportTakesPrecedenceOverAProjectProperty.gradle
@@ -18,10 +18,11 @@ dependencyManagement {
 }
 
 task managedVersions {
+	def output = new File("${buildDir}/managed-versions.txt")
+	def managedVersions = dependencyManagement.managedVersions
 	doFirst {
-		def output = new File("${buildDir}/managed-versions.txt")
 		output.parentFile.mkdirs()
-		dependencyManagement.managedVersions.each { key, value ->
+		managedVersions.each { key, value ->
 			output << "${key} -> ${value}\n"
 		}
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/wildcardExclusionDeclaredInABomIsHonored.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/DMPIT/wildcardExclusionDeclaredInABomIsHonored.gradle
@@ -20,9 +20,9 @@ dependencies {
 }
 
 task resolve {
+	def files = project.configurations.compileClasspath.incoming.files
+	def output = new File("${buildDir}/resolved.txt")
 	doFirst {
-		def files = project.configurations.compileClasspath.resolve()
-		def output = new File("${buildDir}/resolved.txt")
 		output.parentFile.mkdirs()
 		files.collect { it.name }.each { output << "${it}\n" }
 	}

--- a/src/test/resources/io/spring/gradle/dependencymanagement/GVCIT/pluginIsCompatible.gradle
+++ b/src/test/resources/io/spring/gradle/dependencymanagement/GVCIT/pluginIsCompatible.gradle
@@ -18,8 +18,9 @@ dependencies {
 }
 
 task resolve {
+	def runtimeClasspathArtifacts = configurations.runtimeClasspath.incoming.files
 	doFirst {
-		def names = configurations.runtimeClasspath.resolve().collect { it.name }
+		def names = runtimeClasspathArtifacts.collect { it.name }
 		if (!names.containsAll("spring-boot-starter-1.4.2.RELEASE.jar", "spring-boot-1.4.2.RELEASE.jar",
 				"spring-boot-autoconfigure-1.4.2.RELEASE.jar",
 				"spring-boot-starter-logging-1.4.2.RELEASE.jar", "spring-core-4.3.4.RELEASE.jar",


### PR DESCRIPTION
In continuation of https://github.com/spring-gradle-plugins/dependency-management-plugin/pull/391#issuecomment-2286003104

This PR is divided into 3 parts
- [make tests compatible with configuration cache](https://github.com/spring-gradle-plugins/dependency-management-plugin/commit/416c09e22d499fe59bae0dc3d6130c8b7237ae06) 
- [do not apply PomDependencyManagementConfigurer when POM customization is disabled](https://github.com/spring-gradle-plugins/dependency-management-plugin/commit/53cf82ede022295b580b93c7daa5550861f48325). It will allow to change PomConfigurer via a custom plugin
- [allow StandardPomDependencyManagementConfigurer to be configured in compatible with configuration cache way](https://github.com/spring-gradle-plugins/dependency-management-plugin/commit/b229f7bc41b346a2b446ac94f328840f5e22f0bc). Refactor internal API