### PR TITLE
ExclusionResolver makes assumptions that won't hold true with Gradle 9

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionResolver.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/ExclusionResolver.java
@@ -31,8 +31,7 @@ import io.spring.gradle.dependencymanagement.internal.pom.Dependency;
 import io.spring.gradle.dependencymanagement.internal.pom.Pom;
 import io.spring.gradle.dependencymanagement.internal.pom.PomReference;
 import io.spring.gradle.dependencymanagement.internal.pom.PomResolver;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 
 /**
@@ -58,17 +57,16 @@ class ExclusionResolver {
 		List<PomReference> pomReferences = new ArrayList<>();
 		Map<String, Exclusions> exclusionsById = new HashMap<>();
 		for (ResolvedComponentResult resolvedComponent : resolvedComponents) {
-			ModuleVersionIdentifier moduleVersion = resolvedComponent.getModuleVersion();
-			if (!(resolvedComponent.getId() instanceof ProjectComponentIdentifier) && moduleVersion.getGroup() != null
-					&& moduleVersion.getName() != null) {
-				String id = moduleVersion.getGroup() + ":" + moduleVersion.getName();
+			if (resolvedComponent.getId() instanceof ModuleComponentIdentifier) {
+				ModuleComponentIdentifier identifier = (ModuleComponentIdentifier) resolvedComponent.getId();
+				String id = identifier.getGroup() + ":" + identifier.getModule();
 				Exclusions exclusions = this.exclusionsCache.get(id);
 				if (exclusions != null) {
 					exclusionsById.put(id, exclusions);
 				}
 				else {
-					pomReferences.add(new PomReference(new Coordinates(moduleVersion.getGroup(),
-							moduleVersion.getName(), moduleVersion.getVersion())));
+					pomReferences.add(new PomReference(
+							new Coordinates(identifier.getGroup(), identifier.getModule(), identifier.getVersion())));
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a future issue with an upcoming Gradle feature https://github.com/gradle/gradle/issues/30320, where there would be a new non-module-id resulting in a bug similar to
https://github.com/gradle/gradle/issues/30239.

This also fixes a minor bug as it is technically possible for getModuleVersion to return null.