### PR TITLE
dependencyManagement task is eagerly created

### DIFF
--- a/src/main/java/io/spring/gradle/dependencymanagement/internal/bridge/InternalComponents.java
+++ b/src/main/java/io/spring/gradle/dependencymanagement/internal/bridge/InternalComponents.java
@@ -99,7 +99,7 @@ public class InternalComponents {
 	 * @param taskName the task name
 	 */
 	public void createDependencyManagementReportTask(String taskName) {
-		this.project.getTasks().create(taskName, DependencyManagementReportTask.class, this::setupTask);
+		this.project.getTasks().register(taskName, DependencyManagementReportTask.class, this::setupTask);
 	}
 
 	private void setupTask(DependencyManagementReportTask task) {


### PR DESCRIPTION
`TaskContainer.create` methods are marked as obsolete since Gradle 8.12:
```
...
 *
 * @deprecated Use {@link #register(String, Class, Action)} instead. See <a href="https://docs.gradle.org/current/userguide/task_configuration_avoidance.html">documentation</a> for more information.
 */
@Deprecated
@Override
<T extends Task> T create(String name, Class<T> type, Action<? super T> configuration) throws InvalidUserDataException;
```

Also if the `dependency-management-plugin` is added as included build within Gradle 8.12 root build, the compilation fails:
```
./gradlew --include-build ../spring/dependency-management-plugin --scan dependencyManagement
Calculating task graph as no cached configuration is available for tasks: dependencyManagement

> Task :dependency-management-plugin:compileJava FAILED
/Users/user/Projects/spring/dependency-management-plugin/src/main/java/io/spring/gradle/dependencymanagement/internal/bridge/InternalComponents.java:106: warning: [deprecation] <T>create(String,Class<T>,Action<? super T>) in TaskContainer has been deprecated
                this.project.getTasks().create(taskName, DependencyManagementReportTask.class, this::setupTask);
                                       ^
  where T is a type-variable:
    T extends Task declared in method <T>create(String,Class<T>,Action<? super T>)
error: warnings found and -Werror specified
1 error
1 warning
```

The replacement is TaskContainer.register which is available since Gradle 4.9.